### PR TITLE
Fix the failed test

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The variables are:
 * `access_key`
 * `secret_key`
 
-You can then run the test under the `src/test` folder from the Android Studio.
+You can then run the test under the `src/test` folder from the Android Studio or run the command `./gradlew test`.
 
 # Contributing
 

--- a/omisego/build.gradle
+++ b/omisego/build.gradle
@@ -15,7 +15,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/omisego/src/test/kotlin/co/omisego/omisego/networks/RequestorTest.kt
+++ b/omisego/src/test/kotlin/co/omisego/omisego/networks/RequestorTest.kt
@@ -49,7 +49,7 @@ class RequestorTest {
     @Test
     fun `network request headers and body should be matched with the requestOptions`() = runBlocking {
         // Arrange
-        println(Thread.currentThread().name)
+        val beforeThreadName = Thread.currentThread().name
         val requestOptions = RequestOptions().apply {
             setBody(*mockBody.toList().toTypedArray())
             setHeaders(*mockHeaders)
@@ -67,7 +67,7 @@ class RequestorTest {
         val actualBody = MockHttpBin(bodyJson.getString("name"), bodyJson.getDouble("amount"), bodyJson.getBoolean("done"))
 
         // Assert thread
-        Thread.currentThread().name shouldEqual "main" // Validate that we're already in the main thread now.
+        Thread.currentThread().name shouldEqual beforeThreadName // Validate that we're already be backing to the old thread.
 
         // Assert body
         actualBody shouldEqual expectedBody


### PR DESCRIPTION
Issue/Task Number: T851

# Overview

Fix the failed test

# Changes

The assertion of the failed test.

# Implementation Details

When running the test with the Android Studio all tests will pass. If we running the test via the command `./gradlew test`. It will fail 1 test. 

The test validates the before/after thread when running the network request by the SDK should be "main", but when we running the thread with `./gradlew test`, the thread isn't a "main" thread.

# Usage

Run the test with `./gradlew test`

# Impact

None