### PR TITLE
Refactor security package

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 OmiseGo Pte Ltd
+Yannick Badoual yann.badoual@gmail.com

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyHolder.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyHolder.kt
@@ -2,4 +2,11 @@ package co.omisego.omisego.security
 
 import java.security.KeyStore
 
+/**
+ * OmiseGO
+ *
+ * Created by Yannick Badoual on 2/28/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
 internal data class KeyHolder(val keyStore: KeyStore, val keyAlias: String)

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyHolder.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyHolder.kt
@@ -1,0 +1,5 @@
+package co.omisego.omisego.security
+
+import java.security.KeyStore
+
+internal data class KeyHolder(val keyStore: KeyStore, val keyAlias: String)

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManager.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManager.kt
@@ -1,0 +1,57 @@
+package co.omisego.omisego.security
+
+import android.content.Context
+import android.util.Base64
+import java.security.KeyStore
+import javax.crypto.Cipher
+
+/**
+ * OmiseGO
+ *
+ * Copyright © 2017 OmiseGO. All rights reserved.
+ */
+
+internal abstract class KeyManager(private val keyHolder: KeyHolder) {
+
+    protected val keyStore: KeyStore
+        get() = keyHolder.keyStore
+    protected val keyAlias: String
+        get() = keyHolder.keyAlias
+
+    protected abstract val encryptCipher: Cipher
+    protected abstract val decryptCipher: Cipher
+
+    open val b64Mode: Int
+        get() = Base64.DEFAULT
+
+    companion object {
+        const val ANDROID_KEY_STORE = "AndroidKeyStore"
+    }
+
+    fun create(context: Context) {
+        if (!keyStore.containsAlias(keyAlias)) {
+            generateKey(context)
+        }
+    }
+
+    abstract fun generateKey(context: Context)
+
+    abstract fun initCipher(cipher: Cipher, opmode: Int)
+
+    // Encrypt data
+    fun encrypt(input: ByteArray): String {
+        val encodedBytes = synchronized(encryptCipher) {
+            encryptCipher.doFinal(input)
+        }
+        return Base64.encodeToString(encodedBytes, b64Mode)
+    }
+
+    // Decrypt data
+    fun decrypt(encrypted: ByteArray): String {
+        val decoded = Base64.decode(encrypted, b64Mode)
+        val decodedBytes = synchronized(decryptCipher) {
+            decryptCipher.doFinal(decoded)
+        }
+        return String(decodedBytes)
+    }
+}

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManager.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManager.kt
@@ -8,7 +8,8 @@ import javax.crypto.Cipher
 /**
  * OmiseGO
  *
- * Copyright © 2017 OmiseGO. All rights reserved.
+ * Created by Yannick Badoual on 2/28/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
  */
 
 internal abstract class KeyManager(private val keyHolder: KeyHolder) {

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerMarshmallow.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerMarshmallow.kt
@@ -22,7 +22,7 @@ import javax.crypto.spec.GCMParameterSpec
 @RequiresApi(Build.VERSION_CODES.M)
 internal class KeyManagerMarshmallow(
         keyHolder: KeyHolder,
-        private var iv: String = String(ByteArray(12))
+        private val iv: String = String(ByteArray(12))
 ) : KeyManager(keyHolder) {
 
     override val encryptCipher: Cipher by lazy {
@@ -58,7 +58,7 @@ internal class KeyManagerMarshmallow(
     }
 
     override fun initCipher(cipher: Cipher, opmode: Int) {
-        if (opmode !in arrayOf(Cipher.ENCRYPT_MODE, Cipher.ENCRYPT_MODE)) {
+        if (opmode !in arrayOf(Cipher.ENCRYPT_MODE, Cipher.DECRYPT_MODE)) {
             throw IllegalArgumentException("Unsupported opmode $opmode")
         }
         cipher.init(opmode, secretKey, gcmParameterSpec)

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerPreMarshmallow.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerPreMarshmallow.kt
@@ -3,15 +3,10 @@ package co.omisego.omisego.security
 import android.content.Context
 import android.security.KeyPairGeneratorSpec
 import android.util.Base64
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
 import java.math.BigInteger
 import java.security.KeyPairGenerator
-import java.security.KeyStore
 import java.util.*
 import javax.crypto.Cipher
-import javax.crypto.CipherInputStream
-import javax.crypto.CipherOutputStream
 import javax.crypto.spec.SecretKeySpec
 import javax.security.auth.x500.X500Principal
 
@@ -23,92 +18,48 @@ import javax.security.auth.x500.X500Principal
  * Copyright © 2017 OmiseGO. All rights reserved.
  */
 
-internal class KeyManagerPreMarshmallow(private var keyAlias: String) {
-    private val keyStore: KeyStore = KeyStore.getInstance(ANDROID_KEY_STORE)
+internal class KeyManagerPreMarshmallow(
+        keyHolder: KeyHolder,
+        private val keyManagerPreference: KeyManagerPreference
+) : KeyManager(keyHolder) {
+
+    override val encryptCipher: Cipher by lazy { Cipher.getInstance(AES_MODE) }
+    override val decryptCipher: Cipher by lazy { Cipher.getInstance(AES_MODE, "BC") }
+
+    override val b64Mode: Int
+        get() = Base64.NO_WRAP
+
+    private val secretKey: SecretKeySpec?
+        get() = keyManagerPreference.readSecretKey()
 
     companion object {
-        val ANDROID_KEY_STORE = "AndroidKeyStore"
-        val RSA_MODE = "RSA/ECB/PKCS1Padding"
-        val AES_MODE = "AES/ECB/PKCS7Padding"
+        private const val AES_MODE = "AES/ECB/PKCS7Padding"
     }
 
-    fun create(context: Context) {
-        if (!keyStore.containsAlias(keyAlias)) {
-            val start = Calendar.getInstance()
-            val end = Calendar.getInstance()
-            end.add(Calendar.YEAR, 25)
+    override fun generateKey(context: Context) {
+        val start = Calendar.getInstance()
+        val end = Calendar.getInstance().apply {
+            add(Calendar.YEAR, 25)
+        }
 
-            val spec = KeyPairGeneratorSpec.Builder(context)
-                    .setAlias(this.keyAlias)
-                    .setSubject(X500Principal("CN=${keyAlias}"))
-                    .setSerialNumber(BigInteger.TEN)
-                    .setStartDate(start.time)
-                    .setEndDate(end.time)
-                    .build()
+        val spec = KeyPairGeneratorSpec.Builder(context)
+                .setAlias(keyAlias)
+                .setSubject(X500Principal("CN=$keyAlias"))
+                .setSerialNumber(BigInteger.TEN)
+                .setStartDate(start.time)
+                .setEndDate(end.time)
+                .build()
 
-            val kpg = KeyPairGenerator.getInstance("RSA", KeyManagerMarshmallow.ANDROID_KEY_STORE)
-            kpg.initialize(spec)
-            kpg.generateKeyPair()
+        with(KeyPairGenerator.getInstance("RSA", ANDROID_KEY_STORE)) {
+            initialize(spec)
+            generateKeyPair()
         }
     }
 
-    // Encrypt the AES secret with RSA
-    fun rsaEncrypt(secret: ByteArray): ByteArray? {
-        val privateKeyEntry: KeyStore.PrivateKeyEntry = keyStore.getEntry(keyAlias, null) as KeyStore.PrivateKeyEntry
-
-        val inputCipher = Cipher.getInstance(RSA_MODE, "AndroidOpenSSL")
-        inputCipher.init(Cipher.ENCRYPT_MODE, privateKeyEntry.certificate.publicKey)
-        val outputStream = ByteArrayOutputStream()
-        val cipherOutputStream = CipherOutputStream(outputStream, inputCipher)
-        cipherOutputStream.write(secret)
-        cipherOutputStream.close()
-
-        val encrypted = outputStream.toByteArray()
-        return encrypted
-    }
-
-    // Decrypt the AES secret with RSA
-    fun rsaDecrypt(encrypted: ByteArray): ByteArray {
-        val privateKeyEntry = keyStore.getEntry(keyAlias, null) as KeyStore.PrivateKeyEntry
-        val output = Cipher.getInstance(RSA_MODE, "AndroidOpenSSL")
-
-        output.init(Cipher.DECRYPT_MODE, privateKeyEntry.privateKey)
-
-        val cipherInputStream = CipherInputStream(ByteArrayInputStream(encrypted), output)
-
-        val values = mutableListOf<Byte>()
-        while (true) {
-            val nextByte = cipherInputStream.read()
-            if (nextByte == -1) break
-            values.add(nextByte.toByte())
+    override fun initCipher(cipher: Cipher, opmode: Int) {
+        if (opmode !in arrayOf(Cipher.ENCRYPT_MODE, Cipher.ENCRYPT_MODE)) {
+            throw IllegalArgumentException("Unsupported opmode $opmode")
         }
-
-        val bytes = ByteArray(values.size)
-                .mapIndexed { index, _ -> values[index] }
-                .toByteArray()
-
-        return bytes
-    }
-
-    // Encrypt data
-    fun encrypt(input: ByteArray, secretKey: SecretKeySpec): String {
-        val cipher = Cipher.getInstance(AES_MODE)
-        cipher.init(Cipher.ENCRYPT_MODE, secretKey)
-        val encodedBytes = cipher.doFinal(input)
-        val encryptedBase64Encoded = Base64.encodeToString(encodedBytes, Base64.NO_WRAP)
-        return encryptedBase64Encoded
-    }
-
-    // Decrypt data
-    fun decrypt(encrypted: ByteArray, secretKey: SecretKeySpec): String {
-        val cipher = Cipher.getInstance(AES_MODE, "BC")
-        cipher.init(Cipher.DECRYPT_MODE, secretKey)
-        val decodedBase64 = Base64.decode(encrypted, Base64.NO_WRAP)
-        val decodedBytes = cipher.doFinal(decodedBase64)
-        return String(decodedBytes)
-    }
-
-    init {
-        keyStore.load(null)
+        cipher.init(opmode, secretKey)
     }
 }

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerPreMarshmallow.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerPreMarshmallow.kt
@@ -57,7 +57,7 @@ internal class KeyManagerPreMarshmallow(
     }
 
     override fun initCipher(cipher: Cipher, opmode: Int) {
-        if (opmode !in arrayOf(Cipher.ENCRYPT_MODE, Cipher.ENCRYPT_MODE)) {
+        if (opmode !in arrayOf(Cipher.ENCRYPT_MODE, Cipher.DECRYPT_MODE)) {
             throw IllegalArgumentException("Unsupported opmode $opmode")
         }
         cipher.init(opmode, secretKey)

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerPreference.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerPreference.kt
@@ -15,38 +15,31 @@ import javax.crypto.spec.SecretKeySpec
  * Copyright © 2017 OmiseGO. All rights reserved.
  */
 
-internal class KeyManagerPreference(private val context: Context) {
+internal class KeyManagerPreference(context: Context, private val rsaCipher: RSACipher) {
     companion object {
-        val ENCRYPTED_AES_KEY = "encrypted_aes_key"
+        const val ENCRYPTED_AES_KEY = "encrypted_aes_key"
     }
 
-    private val sharePref: SharedPreferences by lazy {
-        context.getSharedPreferences(context.getString(R.string.app_name), Context.MODE_PRIVATE)
+    private val sharePref: SharedPreferences = context.getSharedPreferences(context.getString(R.string.app_name),
+                                                                            Context.MODE_PRIVATE)
+
+    fun saveAESKeyIfAbsent() {
+        if (sharePref.contains(ENCRYPTED_AES_KEY)) return
+
+        val bytes = ByteArray(16)
+        SecureRandom().nextBytes(bytes)
+
+        val encryptedKey = rsaCipher.encrypt(bytes)
+        val encryptedKeyB64 = Base64.encodeToString(encryptedKey, Base64.NO_WRAP)
+
+        sharePref.edit().putString(ENCRYPTED_AES_KEY, encryptedKeyB64).apply()
     }
 
-    fun saveAESKey(keyManager: KeyManagerPreMarshmallow) {
-        val key = sharePref.getString(ENCRYPTED_AES_KEY, "")
-
-        if (key.isEmpty()) {
-            val bytes = ByteArray(16)
-            val secureRandom = SecureRandom()
-            secureRandom.nextBytes(bytes)
-
-            val encryptedKey = keyManager.rsaEncrypt(bytes)
-            val encryptedKeyB64 = Base64.encodeToString(encryptedKey, Base64.NO_WRAP)
-
-            sharePref.edit().putString(ENCRYPTED_AES_KEY, encryptedKeyB64).apply()
-        }
-    }
-
-    fun readSecretKey(keyManager: KeyManagerPreMarshmallow): SecretKeySpec? {
+    fun readSecretKey(): SecretKeySpec {
         val encryptedKeyB64 = sharePref.getString(ENCRYPTED_AES_KEY, null)
-
-        if (encryptedKeyB64 != null) {
-            val encryptedKey = Base64.decode(encryptedKeyB64, Base64.NO_WRAP)
-            val key = keyManager.rsaDecrypt(encryptedKey)
-            return SecretKeySpec(key, "AES")
-        }
-        return null
+                ?: throw IllegalStateException("Key does not exist")
+        val encryptedKey = Base64.decode(encryptedKeyB64, Base64.NO_WRAP)
+        val key = rsaCipher.decrypt(encryptedKey)
+        return SecretKeySpec(key, "AES")
     }
 }

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/OMGKeyManager.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/OMGKeyManager.kt
@@ -3,6 +3,8 @@ package co.omisego.omisego.security
 import android.content.Context
 import android.os.Build
 import java.lang.IllegalArgumentException
+import java.lang.IllegalStateException
+import java.security.KeyStore
 
 /**
  * OmiseGO
@@ -24,118 +26,92 @@ import java.lang.IllegalArgumentException
  * Create instances using [OMGKeyManager.Builder], pass [Context] and [keyAlias] to generate an implementation.
  *
  * For example,
+ *
  * <code>
  * val omgKeyManager = OMGKeyManager.Builder {
- *      initialize(context, "OMGShop")
- * }.build()
+ *      keyAlias = "OMGShop"
+ * }.build(context)
  *
  * val sensitiveData = "OmiseGOKey"
  *
- * val encrypted: String = omgApiClient.encrypt(context, sensitiveData)
- * val decrypted: String = omgApiClient.decrypt(context, encrypted.toByteArray())
+ * val encrypted: String = omgApiClient.encrypt(sensitiveData)
+ * val decrypted: String = omgApiClient.decrypt(encrypted.toByteArray())
  *
  * println(decrypted) // OmiseGOKey
  * </code>
  *
  */
-class OMGKeyManager {
-    private var keyManagerMarshmallow: KeyManagerMarshmallow? = null
-    private var keyManagerPreMarshmallow: KeyManagerPreMarshmallow? = null
+class OMGKeyManager private constructor(private var keyManager: KeyManager) {
 
     /**
      * Build a new [OMGKeyManager].
-     * Calling [Builder.initialize] is required before calling [Builder.build].
      *
      * @receiver A [Builder]'s methods.
      */
     class Builder(init: Builder.() -> Unit) {
-        private lateinit var omgKeyManager: OMGKeyManager
-        private var keyManagerPreMarshmallow: KeyManagerPreMarshmallow? = null
-        private var keyManagerMarshmallow: KeyManagerMarshmallow? = null
+        private lateinit var keyManager: KeyManager
 
-        /**
-         * Initialize KeyManager implementation depends on android version.
-         *
-         * @param context An activity or an application context
-         * @param keyAlias keystore alias
-         */
-        fun initialize(context: Context, keyAlias: String) {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-                keyManagerPreMarshmallow = KeyManagerPreMarshmallow(keyAlias)
-                keyManagerPreMarshmallow!!.create(context)
-                val keyManagerPreference = KeyManagerPreference(context)
-                keyManagerPreference.saveAESKey(keyManagerPreMarshmallow!!)
-            } else {
-                keyManagerMarshmallow = KeyManagerMarshmallow(keyAlias)
-                keyManagerMarshmallow!!.create()
-            }
-        }
-
+        var keyAlias: String = ""
         /**
          * Set Initialization Vector that make it more secure.
          *
-         * Note: IV should be the same value every time.
+         * Note: IV should be the same value every time and always 12 characters long.
          * Instead, you can't decrypt the data that encrypted with different IV.
          *
          * See more [https://en.wikipedia.org/wiki/Initialization_vector]
-         *
-         * @param iv A string with 12 characters
          */
-        fun setIV(iv: String) {
-            if (iv.length != 12) throw IllegalArgumentException("The string should be contains 12 characters.")
-            keyManagerMarshmallow?.setIV(iv)
+        var iv: String = String(ByteArray(12))
+            set(value) {
+                if (value.length != 12) throw IllegalArgumentException("The string should be contains 12 characters.")
+                field = value
+            }
+
+
+        init {
+            init()
         }
 
         /**
          * Create the [OMGKeyManager] instance using the configured values.
-         * Note: Calling [Builder.initialize] is required before calling this.
+         * @param context An activity or application context
          */
-        fun build(): OMGKeyManager {
-            omgKeyManager = OMGKeyManager()
-            omgKeyManager.keyManagerMarshmallow = keyManagerMarshmallow
-            omgKeyManager.keyManagerPreMarshmallow = keyManagerPreMarshmallow
-            return omgKeyManager
-        }
+        fun build(context: Context): OMGKeyManager {
+            if (keyAlias.isBlank()) throw IllegalStateException("keyAlias not set")
 
-        init {
-            init()
+            val keyStore = KeyStore.getInstance(KeyManager.ANDROID_KEY_STORE)
+            val keyHolder = KeyHolder(keyStore, keyAlias)
+
+            keyManager =
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                        val rsaCipher = RSACipher(keyHolder)
+                        val keyManagerPreference = KeyManagerPreference(context, rsaCipher)
+                        keyManagerPreference.saveAESKeyIfAbsent()
+
+                        KeyManagerPreMarshmallow(keyHolder, keyManagerPreference)
+                    } else {
+                        KeyManagerMarshmallow(keyHolder, iv)
+                    }
+            keyManager.create(context)
+
+            return OMGKeyManager(keyManager)
         }
     }
 
     /**
      * Encrypt the data
      *
-     * @param context An activity or an application context
      * @param input The sensitive data [ByteArray]
      *
      * @return An encrypted string
      */
-    fun encrypt(context: Context, input: ByteArray): String {
-        return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            val secretKeySpec = KeyManagerPreference(context).readSecretKey(keyManagerPreMarshmallow!!) ?:
-                    throw IllegalAccessException("OMGKeyManager has not been initialized!")
-
-            keyManagerPreMarshmallow!!.encrypt(input, secretKeySpec)
-        } else {
-            keyManagerMarshmallow!!.encrypt(input)
-        }
-    }
+    fun encrypt(input: ByteArray): String = keyManager.encrypt(input)
 
     /**
      * Decrypt the data
      *
-     * @param context An activity or an application context
-     * @param input The sensitive data [ByteArray]
+     * @param encrypted The sensitive data [ByteArray]
      *
      * @return An original string before encryption
      */
-    fun decrypt(context: Context, encrypted: ByteArray): String {
-        return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            val secretKeySpec = KeyManagerPreference(context).readSecretKey(keyManagerPreMarshmallow!!) ?:
-                    throw IllegalAccessException("OMGKeyManager has not been initialized!")
-            keyManagerPreMarshmallow!!.decrypt(encrypted, secretKeySpec)
-        } else {
-            keyManagerMarshmallow!!.decrypt(encrypted)
-        }
-    }
+    fun decrypt(encrypted: ByteArray): String = keyManager.decrypt(encrypted)
 }

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/RSACipher.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/RSACipher.kt
@@ -7,6 +7,13 @@ import javax.crypto.Cipher
 import javax.crypto.CipherInputStream
 import javax.crypto.CipherOutputStream
 
+/**
+ * OmiseGO
+ *
+ * Created by Yannick Badoual on 2/28/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
 internal class RSACipher(private val keyHolder: KeyHolder) {
 
     private val keyStore: KeyStore

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/RSACipher.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/RSACipher.kt
@@ -1,0 +1,58 @@
+package co.omisego.omisego.security
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.CipherInputStream
+import javax.crypto.CipherOutputStream
+
+internal class RSACipher(private val keyHolder: KeyHolder) {
+
+    private val keyStore: KeyStore
+        get() = keyHolder.keyStore
+    private val keyAlias: String
+        get() = keyHolder.keyAlias
+    private val privateKeyEntry: KeyStore.PrivateKeyEntry
+        get() = keyStore.getEntry(keyAlias, null) as KeyStore.PrivateKeyEntry
+
+    private val cipher: Cipher
+        get() = Cipher.getInstance(RSA_MODE, RSA_PROVIDER)
+
+    companion object {
+        private const val RSA_MODE = "RSA/ECB/PKCS1Padding"
+        private const val RSA_PROVIDER = "AndroidOpenSSL"
+    }
+
+    // Encrypt the AES secret with RSACipher
+    fun encrypt(secret: ByteArray): ByteArray {
+        val inputCipher = cipher
+        inputCipher.init(Cipher.ENCRYPT_MODE, privateKeyEntry.certificate.publicKey)
+
+        val outputStream = ByteArrayOutputStream()
+        val cipherOutputStream = CipherOutputStream(outputStream, inputCipher)
+        cipherOutputStream.write(secret)
+        cipherOutputStream.close()
+
+        return outputStream.toByteArray()
+    }
+
+    // Decrypt the AES secret with RSACipher
+    fun decrypt(encrypted: ByteArray): ByteArray {
+        val output = cipher
+        output.init(Cipher.DECRYPT_MODE, privateKeyEntry.privateKey)
+
+        val cipherInputStream = CipherInputStream(ByteArrayInputStream(encrypted), output)
+
+        val values = mutableListOf<Byte>()
+        while (true) {
+            val nextByte = cipherInputStream.read()
+            if (nextByte == -1) break
+            values.add(nextByte.toByte())
+        }
+
+        return ByteArray(values.size)
+                .mapIndexed { index, _ -> values[index] }
+                .toByteArray()
+    }
+}


### PR DESCRIPTION
Issue/Task Number:

# Overview

Refactor security package to have a common superclass for both KeyManager implementation. By doing so, we can hide the actual type from the `OMGKeyManager`.

# Changes

- Introduce a `KeyHolder` class to hodl keystore + keyalias values, to inject across all the classes
- Add `KeyManager` superclass (both implementation extends it)
- Extract rsa encryption/decryption into `RSACipher` class 
- Re-use cipher in `KeyManager` with a lock on it to be thread-safe
- `KeyManagerPreference` doesn't depend anymore on `KeyManagerPreMarshmallow` (it was causing a circular dependency, even if hidden)
- The `secretKey` in `KeyManagerPreMarshmallow` is now read from preferences only when initializing cipher. There's no apparent reason to re-read it every time, since it's updated before the creating of the `KeyManagerPreMarshmallow`
- `OMGKeyManager` usage now changes a bit. No need to pass the context anymore when calling `encrypt` / `decrypt`.
- On `OMGKeyManager.Builder`, `keyAlias` and `iv` are now properties instead of setter functions

# Implementation Details

Cipher are now re-used, which should improve performances. 

# Usage

You can now build the `OMGKeyManager.Builder` like this:

```kotlin
OMGKeyManager.Builder {
    keyAlias = "OMGShop"
    iv = "abcdefghijkl" // Optional
}.build(context)
```

# Impact

Shouldn't cause any regression.

# Next steps

We could probably introduce an interface with `encrypt` / `decrypt` methods (or one interface for each) and make `OMGKeyManager` implement them by delegate on the `keyManager` property, would simplify the code. I could also do this in this PR is you want me to.
In `RSACipher`, the `decrypt` method seems very inefficient. We should be able to do better than reading bytes one by one. Maybe use a `BufferedInputStream`.

# Note

Tried to update the doc, if I missed a place tell me.