### PR TITLE
Fix encryption bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.30'
+    ext.kotlin_version = '1.2.31'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.15"
         classpath 'com.novoda:bintray-release:0.8.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 03 14:37:36 ICT 2017
+#Tue Mar 27 11:55:16 ICT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerMarshmallow.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerMarshmallow.kt
@@ -31,7 +31,8 @@ internal class KeyManagerMarshmallow(
 
     private val secretKey: Key
         get() = keyStore.getKey(keyAlias, null)
-    private val gcmParameterSpec: GCMParameterSpec = GCMParameterSpec(128, iv.toByteArray())
+
+    private val gcmParameterSpec = GCMParameterSpec(128, iv.toByteArray())
 
     companion object {
         const val AES_MODE = "AES/GCM/NoPadding"

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerMarshmallow.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerMarshmallow.kt
@@ -10,7 +10,6 @@ import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.spec.GCMParameterSpec
 
-
 /**
  * OmiseGO
  *
@@ -21,21 +20,20 @@ import javax.crypto.spec.GCMParameterSpec
 // IV or Initialization Vector used in encryption and decryption. It must be the same value and contain 12 characters.
 @RequiresApi(Build.VERSION_CODES.M)
 internal class KeyManagerMarshmallow(
-        keyHolder: KeyHolder,
-        private val iv: String = String(ByteArray(12))
+    keyHolder: KeyHolder,
+    iv: String = String(ByteArray(12))
 ) : KeyManager(keyHolder) {
 
-    override val encryptCipher: Cipher by lazy {
-        Cipher.getInstance(AES_MODE).also { initCipher(it, Cipher.ENCRYPT_MODE) }
-    }
-    override val decryptCipher: Cipher by lazy {
-        Cipher.getInstance(AES_MODE).also { initCipher(it, Cipher.DECRYPT_MODE) }
-    }
+    private val cipher by lazy { Cipher.getInstance(AES_MODE) }
+
+    override val encryptCipher: Cipher
+        get() = cipher.also { initCipher(it, Cipher.ENCRYPT_MODE) }
+    override val decryptCipher: Cipher
+        get() = cipher.also { initCipher(it, Cipher.DECRYPT_MODE) }
 
     private val secretKey: Key
         get() = keyStore.getKey(keyAlias, null)
-    private val gcmParameterSpec: GCMParameterSpec
-        get() = GCMParameterSpec(128, iv.toByteArray())
+    private val gcmParameterSpec: GCMParameterSpec = GCMParameterSpec(128, iv.toByteArray())
 
     companion object {
         const val AES_MODE = "AES/GCM/NoPadding"
@@ -43,15 +41,16 @@ internal class KeyManagerMarshmallow(
 
     // Generate key function for Android version 6.0 Marshmallow or above
     override fun generateKey(context: Context) {
-        val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES,
-                                                    ANDROID_KEY_STORE)
+        val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE)
 
-        val spec = KeyGenParameterSpec.Builder(keyAlias,
-                                               KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
-                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                .setRandomizedEncryptionRequired(false)
-                .build()
+        val spec = KeyGenParameterSpec.Builder(
+            keyAlias,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setRandomizedEncryptionRequired(false)
+            .build()
 
         keyGenerator.init(spec)
         keyGenerator.generateKey()

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerMarshmallow.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerMarshmallow.kt
@@ -23,13 +23,11 @@ internal class KeyManagerMarshmallow(
     keyHolder: KeyHolder,
     iv: String = String(ByteArray(12))
 ) : KeyManager(keyHolder) {
-
-    private val cipher by lazy { Cipher.getInstance(AES_MODE) }
-
+    
     override val encryptCipher: Cipher
-        get() = cipher.also { initCipher(it, Cipher.ENCRYPT_MODE) }
+        get() = Cipher.getInstance(AES_MODE).also { initCipher(it, Cipher.ENCRYPT_MODE) }
     override val decryptCipher: Cipher
-        get() = cipher.also { initCipher(it, Cipher.DECRYPT_MODE) }
+        get() = Cipher.getInstance(AES_MODE).also { initCipher(it, Cipher.DECRYPT_MODE) }
 
     private val secretKey: Key
         get() = keyStore.getKey(keyAlias, null)

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/OMGKeyManager.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/OMGKeyManager.kt
@@ -66,7 +66,6 @@ class OMGKeyManager private constructor(private var keyManager: KeyManager) {
                 field = value
             }
 
-
         init {
             init()
         }

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/OMGKeyManager.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/OMGKeyManager.kt
@@ -79,6 +79,7 @@ class OMGKeyManager private constructor(private var keyManager: KeyManager) {
             if (keyAlias.isBlank()) throw IllegalStateException("keyAlias not set")
 
             val keyStore = KeyStore.getInstance(KeyManager.ANDROID_KEY_STORE)
+            keyStore.load(null)
             val keyHolder = KeyHolder(keyStore, keyAlias)
 
             keyManager =

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/OMGKeyManager.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/OMGKeyManager.kt
@@ -77,8 +77,7 @@ class OMGKeyManager private constructor(private var keyManager: KeyManager) {
         fun build(context: Context): OMGKeyManager {
             if (keyAlias.isBlank()) throw IllegalStateException("keyAlias not set")
 
-            val keyStore = KeyStore.getInstance(KeyManager.ANDROID_KEY_STORE)
-            keyStore.load(null)
+            val keyStore = KeyStore.getInstance(KeyManager.ANDROID_KEY_STORE).apply { load(null) }
             val keyHolder = KeyHolder(keyStore, keyAlias)
 
             keyManager =


### PR DESCRIPTION
Issue/Task Number: 155-fix-encryption-bug

# Overview

Currently, we have some serious bugs in the `OMGKeyManager` class.

1. `KeyStoreException: Uninitialized Keystore`, every time we called function `build` in the `OMGKeyManager` class

2. `IllegalStateException: IV has already been used.`

In the `KeyManagerMarshmallow`, we **reuse** the `Cipher` object every time we use it for `encrypt/decrypt`, so the class will throw an exception if we won't change the `IV`

We want to keep the same `IV` because of the security provided by `AndroidKeyStore`, a random IV is an overkill here. So we need to **re-initialize** the `Cipher` every time that we need to use it.

# Changes

The initialize steps in the `KeyManagerMarshMallow` and `OMGKeyManager`

# Implementation Details

1. Add `keyStore.load(null)` to solve the first bug.
2. Change the initialization step of `encryptCipher` and `decryptCipher` from `lazy` to `get`, so every time we access this variable it will re-initialize the cipher. This will solve another bug.

# Usage

```kotlin
val keyManager = OMGKeyManager.Builder {
    keyAlias = "OMG"
    iv = "OMG123456789" // A string with 12 characters
}.build(this)

val encrypted = keyManager.encrypt("Something".toByteArray()) // An encrypted string
val decrypted = keyManager.decrypt(encrypted.toByteArray()) // "Something"
```

# Impact

Will solve the bugs