### PR TITLE
Implement QR code transaction request generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /local.properties
 /.idea/workspace.xml
 /.idea/libraries
+/.idea/caches/**
 .DS_Store
 /build
 /captures

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ val request = TransactionRequestCreateParams(
     correlationId = "correlation_id"
 )
 
-omgAPIClient.generateTransactionRequest(request).enqueue(object : OMGCallback<TransactionRequest> {
+omgAPIClient.createTransactionRequest(request).enqueue(object : OMGCallback<TransactionRequest> {
     override fun success(response: OMGResponse<TransactionRequest>) {
         //TODO: Do something with the transaction request (get the QR code representation for example)
         val qrBitmap = response.data.generateQRCode(512)) // Generate the QR bitmap

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ The [OmiseGO](https://omisego.network) Android SDK allows developers to easily i
     - [Get the current user](#get-the-current-user)
     - [Get the addresses of the current user](#get-the-addresses-of-the-current-user)
     - [Get the provider settings](#get-the-provider-settings)
+    - [Get the current user's transactions](#get-the-current-users-transactions)
+  - [QR codes](#qr-codes)
+    - [Generation](#generation)
 - [Test](#test)
 - [Contributing](#contributing)
 - [License](#license)
@@ -56,7 +59,7 @@ Where:
 `baseURL` is the URL of the OmiseGO Wallet API.
 > You can find more info on how to retrieve this token in the OmiseGO server SDK documentations.
 
-### Retrieving resources
+## Retrieving resources
 
 Once you have an initialized client, you can retrieve different resources.
 Each call takes a `OMGCallback` interface that returns a `OMGResponse` object:
@@ -156,21 +159,21 @@ Where
     
     > `import co.omisego.omisego.model.pagination.SortDirection.*`
     
-* `searchTerm` *(nullable)* is a term to search for all of the searchable fields. 
+* `searchTerm` *(optional)* is a term to search for all of the searchable fields. 
       Conflict with `searchTerms`, only use one of them. The available values are:
     
     `ID`, `STATUS`, `FROM`, `TO`, `CREATED_AT`, `UPDATED_AT`
       
     > `import co.omisego.omisego.model.pagination.Paginable.Transaction.SearchableFields.*`
     
-* `searchTerms` *(nullable)* is a key-value map of fields to search with the available fields (same as `searchTerm`)
+* `searchTerms` *(optional)* is a key-value map of fields to search with the available fields (same as `searchTerm`)
     For example:
     
     ```kotlin
     mapOf(FROM to "some_address", ID to "some_id")
     ```
 
-* `address` *(nullable)* is an optional address that belongs to the current user (primary address by default)
+* `address` *(optional)* is an optional address that belongs to the current user (primary address by default)
 
 Then you can call:
 
@@ -197,8 +200,44 @@ Where:
     * `currentPage` is the retrieved page.
     * `isFirstPage` is a bool indicating if the page received is the first page
     * `isLastPage` is a bool indicating if the page received is the last page
-    
-    
+
+## QR Codes
+This SDK offers the possibility to generate request Typically these actions should be done through the generation and scan of QR codes.
+
+### Generation
+To generate a new transaction request you can call:
+
+```kotlin
+val request = TransactionRequestCreateParams(
+    type = TransactionRequestType.RECEIVE,
+    tokenId = "a_token_id",
+    amount = 10.24
+    address = "receiver_address"
+    correlationId = "correlation_id"
+)
+
+omgAPIClient.generateTransactionRequest(request).enqueue(object : OMGCallback<TransactionRequest> {
+    override fun success(response: OMGResponse<TransactionRequest>) {
+        //TODO: Do something with the transaction request (get the QR code representation for example)
+        val qrBitmap = response.data.generateQRCode(512)) // Generate the QR bitmap
+    }
+
+    override fun fail(response: OMGResponse<APIError>) {
+        //TODO: Handle the error
+    }
+})
+```
+
+Where:
+* `request` is a `TransactionRequestCreateParams` data class constructed using:
+    * `type`: The QR code type, only supports `TransactionRequestType.RECEIVE` for now.
+    * `tokenId`: The id of the desired token.
+    * `amount`: (optional) The amount of token to receive. This amount can be either inputted when generating or consuming a transaction request.
+    * `address`: (optional) The address specifying where the transaction should be sent to. If not specified, the current user's primary address will be used.
+    * `correlationId`: (optional) An id that can uniquely identify a transaction. Typically an order id from a provider.
+
+A `TransactionRequest` object is passed to the success callback, you can get its QR code representation using `transactionRequest.generateQRCode(size)`.
+
 # Run Kotlin Lint
 Simply run `./gradlew ktlintCheck` under project root directory.
 

--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ To generate a new transaction request you can call:
 val request = TransactionRequestParams(
     type = TransactionRequestType.RECEIVE,
     tokenId = "a_token_id",
-    amount = 10.24
-    address = "receiver_address"
+    amount = 10_240, /* If the token has subUnitToUnit = 1,000, it means this request want to receive 10.24 OMG */
+    address = "receiver_address",
     correlationId = "correlation_id"
 )
 

--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ omgAPIClient.getSettings().enqueue(object: OMGCallback<Setting>{
 ### Get the current user's transactions
 This returns a paginated filtered list of transactions.
 
-In order to get this list you will need to create a `TransactionListParams` object:
+In order to get this list you will need to create a `ListTransactionParams` object:
 
 ```kotlin
-val request = TransactionListParams.create(
+val request = ListTransactionParams.create(
     page = 1,
     perPage = 10,
     sortBy = Paginable.Transaction.SortableFields.CREATE_AT,
@@ -208,7 +208,7 @@ This SDK offers the possibility to generate and consume transaction requests. Ty
 To generate a new transaction request you can call:
 
 ```kotlin
-val request = TransactionRequestCreateParams(
+val request = TransactionRequestParams(
     type = TransactionRequestType.RECEIVE,
     tokenId = "a_token_id",
     amount = 10.24
@@ -229,7 +229,7 @@ omgAPIClient.createTransactionRequest(request).enqueue(object : OMGCallback<Tran
 ```
 
 Where:
-* `request` is a `TransactionRequestCreateParams` data class constructed using:
+* `request` is a `TransactionRequestParams` data class constructed using:
     * `type`: The QR code type, only supports `TransactionRequestType.RECEIVE` for now.
     * `tokenId`: The id of the desired token.
     * `amount`: (optional) The amount of token to receive. This amount can be either inputted when generating or consuming a transaction request.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Where:
     * `isLastPage` is a bool indicating if the page received is the last page
 
 ## QR Codes
-This SDK offers the possibility to generate request Typically these actions should be done through the generation and scan of QR codes.
+This SDK offers the possibility to generate and consume transaction requests. Typically these actions should be done through the generation and scan of QR codes.
 
 ### Generation
 To generate a new transaction request you can call:

--- a/build.gradle
+++ b/build.gradle
@@ -30,5 +30,5 @@ task clean(type: Delete) {
 }
 
 ext {
-    versionName = "0.9.2"
+    versionName = "0.9.3"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.enableD8=true
+android.enableAapt2=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Tue Mar 27 11:55:16 ICT 2018
+#Tue Mar 27 15:02:14 ICT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/omisego-sdk/build.gradle
+++ b/omisego-sdk/build.gradle
@@ -65,6 +65,10 @@ tasks.withType(Javadoc) {
 dependencies {
     // Core dependencies
     api "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
+    // Used for the QRCode generator and the QRCode scanner.
+    // It is an android port version of Google's ZXing library.
+    api 'com.journeyapps:zxing-android-embedded:3.2.0'
     implementation 'com.android.support:support-annotations:27.1.0'
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.4.0'

--- a/omisego-sdk/src/main/java/co/omisego/omisego/OMGAPIClient.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/OMGAPIClient.kt
@@ -10,7 +10,8 @@ package co.omisego.omisego
 import co.omisego.omisego.model.Address
 import co.omisego.omisego.model.Setting
 import co.omisego.omisego.model.User
-import co.omisego.omisego.model.transaction.TransactionListParams
+import co.omisego.omisego.model.transaction.list.TransactionListParams
+import co.omisego.omisego.model.transaction.request.TransactionRequestCreateParams
 import co.omisego.omisego.network.ewallet.EWalletClient
 
 /**
@@ -80,14 +81,21 @@ class OMGAPIClient(private val eWalletClient: EWalletClient) {
      */
     fun listBalances() = eWalletAPI.listBalances()
 
-
     /**
      * Get a paginated list of transaction for the current user
      *
      * @param request A structure used to query a list of transactions for the current user
      */
     fun listTransactions(request: TransactionListParams) =
-            eWalletAPI.listTransactions(request)
+        eWalletAPI.listTransactions(request)
+
+    /**
+     * Generate a transaction request from the given TransactionRequestParams object
+     *
+     * @param request The [TransactionRequestCreateParams] object describing the transaction request to be made.
+     */
+    fun generateTransactionRequest(request: TransactionRequestCreateParams) =
+        eWalletAPI.createTransactionRequest(request)
 
     /**
      * Set new [authenticationToken].

--- a/omisego-sdk/src/main/java/co/omisego/omisego/OMGAPIClient.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/OMGAPIClient.kt
@@ -94,7 +94,7 @@ class OMGAPIClient(private val eWalletClient: EWalletClient) {
      *
      * @param request The [TransactionRequestCreateParams] object describing the transaction request to be made.
      */
-    fun generateTransactionRequest(request: TransactionRequestCreateParams) =
+    fun createTransactionRequest(request: TransactionRequestCreateParams) =
         eWalletAPI.createTransactionRequest(request)
 
     /**

--- a/omisego-sdk/src/main/java/co/omisego/omisego/OMGAPIClient.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/OMGAPIClient.kt
@@ -10,8 +10,8 @@ package co.omisego.omisego
 import co.omisego.omisego.model.Address
 import co.omisego.omisego.model.Setting
 import co.omisego.omisego.model.User
-import co.omisego.omisego.model.transaction.list.TransactionListParams
-import co.omisego.omisego.model.transaction.request.TransactionRequestCreateParams
+import co.omisego.omisego.model.transaction.list.ListTransactionParams
+import co.omisego.omisego.model.transaction.request.TransactionRequestParams
 import co.omisego.omisego.network.ewallet.EWalletClient
 
 /**
@@ -86,15 +86,15 @@ class OMGAPIClient(private val eWalletClient: EWalletClient) {
      *
      * @param request A structure used to query a list of transactions for the current user
      */
-    fun listTransactions(request: TransactionListParams) =
+    fun listTransactions(request: ListTransactionParams) =
         eWalletAPI.listTransactions(request)
 
     /**
      * Generate a transaction request from the given [TransactionRequestParams] object
      *
-     * @param request The [TransactionRequestCreateParams] object describing the transaction request to be made.
+     * @param request The [TransactionRequestParams] object describing the transaction request to be made.
      */
-    fun createTransactionRequest(request: TransactionRequestCreateParams) =
+    fun createTransactionRequest(request: TransactionRequestParams) =
         eWalletAPI.createTransactionRequest(request)
 
     /**

--- a/omisego-sdk/src/main/java/co/omisego/omisego/OMGAPIClient.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/OMGAPIClient.kt
@@ -90,7 +90,7 @@ class OMGAPIClient(private val eWalletClient: EWalletClient) {
         eWalletAPI.listTransactions(request)
 
     /**
-     * Generate a transaction request from the given TransactionRequestParams object
+     * Generate a transaction request from the given [TransactionRequestParams] object
      *
      * @param request The [TransactionRequestCreateParams] object describing the transaction request to be made.
      */

--- a/omisego-sdk/src/main/java/co/omisego/omisego/constant/Endpoints.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/constant/Endpoints.kt
@@ -12,5 +12,6 @@ object Endpoints {
     const val LOGOUT = "logout"
     const val LIST_BALANCE = "me.list_balances"
     const val LIST_TRANSACTIONS = "me.list_transactions"
+    const val CREATE_TRANSACTION_REQUEST = "me.create_transaction_request"
     const val GET_SETTINGS = "me.get_settings"
 }

--- a/omisego-sdk/src/main/java/co/omisego/omisego/custom/gson/OMGEnumAdapter.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/custom/gson/OMGEnumAdapter.kt
@@ -11,18 +11,16 @@ import co.omisego.omisego.constant.enums.OMGEnum
 import com.google.gson.JsonDeserializationContext
 import com.google.gson.JsonDeserializer
 import com.google.gson.JsonElement
-import com.google.gson.JsonPrimitive
-import com.google.gson.JsonSerializationContext
 import com.google.gson.JsonSerializer
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonPrimitive
 import java.lang.reflect.Type
 
 @Suppress("UNCHECKED_CAST")
 internal class OMGEnumAdapter<T: OMGEnum> : JsonDeserializer<T>, JsonSerializer<T> {
-    private var values: Map<String, T>? = null
-
     override fun deserialize(json: JsonElement, type: Type, context: JsonDeserializationContext): T? {
         val enumConstants = (type as Class<T>).enumConstants
-        return (values ?: enumConstants.associateBy { it.value }.also { values = it })[json.asString]
+        return enumConstants.firstOrNull { it.value == json.asString }
     }
 
     override fun serialize(src: T, type: Type, context: JsonSerializationContext): JsonElement {

--- a/omisego-sdk/src/main/java/co/omisego/omisego/custom/gson/OMGEnumAdapter.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/custom/gson/OMGEnumAdapter.kt
@@ -8,11 +8,16 @@ package co.omisego.omisego.custom.gson
  */
 
 import co.omisego.omisego.constant.enums.OMGEnum
-import com.google.gson.*
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
 import java.lang.reflect.Type
 
 @Suppress("UNCHECKED_CAST")
-internal class OMGEnumAdapter<T> : JsonDeserializer<T>, JsonSerializer<T> where T : OMGEnum, T : Enum<T> {
+internal class OMGEnumAdapter<T: OMGEnum> : JsonDeserializer<T>, JsonSerializer<T> {
     private var values: Map<String, T>? = null
 
     override fun deserialize(json: JsonElement, type: Type, context: JsonDeserializationContext): T? {

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/list/Transaction.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/list/Transaction.kt
@@ -9,13 +9,14 @@ package co.omisego.omisego.model.transaction.list
 
 import co.omisego.omisego.model.MintedToken
 import co.omisego.omisego.model.pagination.Paginable
-import java.util.*
+import java.math.BigDecimal
+import java.util.Date
 
 data class TransactionExchange(val rate: Double)
 
 data class TransactionSource(
         val address: String,
-        val amount: Int,
+        val amount: BigDecimal,
         val mintedToken: MintedToken
 )
 

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/list/Transaction.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/list/Transaction.kt
@@ -9,13 +9,13 @@ package co.omisego.omisego.model.transaction.list
 
 import co.omisego.omisego.model.MintedToken
 import co.omisego.omisego.model.pagination.Paginable
-import java.util.Date
+import java.util.*
 
 data class TransactionExchange(val rate: Double)
 
 data class TransactionSource(
         val address: String,
-        val amount: Double,
+        val amount: Int,
         val mintedToken: MintedToken
 )
 

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/list/Transaction.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/list/Transaction.kt
@@ -1,4 +1,4 @@
-package co.omisego.omisego.model.transaction
+package co.omisego.omisego.model.transaction.list
 
 /*
  * OmiseGO
@@ -9,7 +9,7 @@ package co.omisego.omisego.model.transaction
 
 import co.omisego.omisego.model.MintedToken
 import co.omisego.omisego.model.pagination.Paginable
-import java.util.*
+import java.util.Date
 
 data class TransactionExchange(val rate: Double)
 

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/list/TransactionListParams.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/list/TransactionListParams.kt
@@ -14,7 +14,7 @@ import co.omisego.omisego.model.pagination.SortDirection
  *  Represent a structure used to query a list of transactions
  */
 
-data class TransactionListParams internal constructor(
+data class ListTransactionParams internal constructor(
         /**
          * A page number
          */
@@ -74,7 +74,7 @@ data class TransactionListParams internal constructor(
                 sortDirection: SortDirection = SortDirection.DESCENDING,
                 searchTerm: String? = null,
                 address: String? = null
-        ) = TransactionListParams(
+        ) = ListTransactionParams(
             page = page,
             perPage = perPage,
             sortBy = sortBy,
@@ -90,7 +90,7 @@ data class TransactionListParams internal constructor(
                 sortDirection: SortDirection = SortDirection.DESCENDING,
                 searchTerms: Map<Paginable.Transaction.SearchableFields, Any>? = null,
                 address: String? = null
-        ) = TransactionListParams(
+        ) = ListTransactionParams(
             page = page,
             perPage = perPage,
             sortBy = sortBy,

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/list/TransactionListParams.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/list/TransactionListParams.kt
@@ -1,4 +1,4 @@
-package co.omisego.omisego.model.transaction
+package co.omisego.omisego.model.transaction.list
 
 /*
  * OmiseGO
@@ -75,12 +75,12 @@ data class TransactionListParams internal constructor(
                 searchTerm: String? = null,
                 address: String? = null
         ) = TransactionListParams(
-                page = page,
-                perPage = perPage,
-                sortBy = sortBy,
-                sortDirection = sortDirection,
-                searchTerm = searchTerm,
-                address = address
+            page = page,
+            perPage = perPage,
+            sortBy = sortBy,
+            sortDirection = sortDirection,
+            searchTerm = searchTerm,
+            address = address
         )
 
         fun create(
@@ -91,12 +91,12 @@ data class TransactionListParams internal constructor(
                 searchTerms: Map<Paginable.Transaction.SearchableFields, Any>? = null,
                 address: String? = null
         ) = TransactionListParams(
-                page = page,
-                perPage = perPage,
-                sortBy = sortBy,
-                sortDirection = sortDirection,
-                searchTerms = searchTerms,
-                address = address
+            page = page,
+            perPage = perPage,
+            sortBy = sortBy,
+            sortDirection = sortDirection,
+            searchTerms = searchTerms,
+            address = address
         )
     }
 }

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequest.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequest.kt
@@ -13,6 +13,7 @@ import co.omisego.omisego.qrcode.QRGenerator
 
 /**
  * Represents a transaction request
+ * 
  */
 data class TransactionRequest(
     val id: String,
@@ -21,5 +22,12 @@ data class TransactionRequest(
     val amount: Double?,
     val address: String?
 ) {
+
+    /**
+     * Generates an QR bitmap containing the encoded transaction request id
+     *
+     * @param size the desired image size
+     * @return An QR image if the transaction request was successfully encoded
+     */
     fun generateQRCode(size: Int = QRGenerator.DEFAULT_SIZE): Bitmap = QRGenerator().generate(id, size)
 }

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequest.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequest.kt
@@ -19,6 +19,7 @@ data class TransactionRequest(
     val id: String,
     val type: TransactionRequestType,
     val mintedToken: MintedToken,
+    val status: String,
     val amount: Double?,
     val address: String?
 ) {

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequest.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequest.kt
@@ -7,9 +7,7 @@ package co.omisego.omisego.model.transaction.request
  * Copyright © 2017-2018 OmiseGO. All rights reserved.
  */
 
-import android.graphics.Bitmap
 import co.omisego.omisego.model.MintedToken
-import co.omisego.omisego.qrcode.QRGenerator
 
 /**
  * Represents a transaction request
@@ -22,13 +20,4 @@ data class TransactionRequest(
     val status: String,
     val amount: Double?,
     val address: String?
-) {
-
-    /**
-     * Generates an QR bitmap containing the encoded transaction request id
-     *
-     * @param size the desired image size
-     * @return An QR image if the transaction request was successfully encoded
-     */
-    fun generateQRCode(size: Int = QRGenerator.DEFAULT_SIZE): Bitmap = QRGenerator().generate(id, size)
-}
+)

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequest.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequest.kt
@@ -1,0 +1,25 @@
+package co.omisego.omisego.model.transaction.request
+
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 27/3/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
+import android.graphics.Bitmap
+import co.omisego.omisego.model.MintedToken
+import co.omisego.omisego.qrcode.QRGenerator
+
+/**
+ * Represents a transaction request
+ */
+data class TransactionRequest(
+    val id: String,
+    val type: TransactionRequestType,
+    val mintedToken: MintedToken,
+    val amount: Double?,
+    val address: String?
+) {
+    fun generateQRCode(size: Int = QRGenerator.DEFAULT_SIZE): Bitmap = QRGenerator().generate(id, size)
+}

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
@@ -6,10 +6,27 @@ package co.omisego.omisego.model.transaction.request
  * Created by Phuchit Sirimongkolsathien on 27/3/2018 AD.
  * Copyright © 2017-2018 OmiseGO. All rights reserved.
  */
+
+/**
+ * Represents a structure used to generate a transaction request
+ *
+ */
 data class TransactionRequestCreateParams(
+
+    /* The type of transaction to be generated */
     val type: TransactionRequestType = TransactionRequestType.RECEIVE,
+
+    /* The id of the desired token */
     val tokenId: String,
+
+    /* The amount of token to receive
+       This amount can be either inputted when generating or consuming a transaction request. */
     val amount: Int? = null,
+
+    /* The address specifying where the transaction should be sent to.
+       If not specified, the current user's primary address will be used. */
     val address: String? = null,
+
+    /* An id that can uniquely identify a transaction. Typically an order id from a provider. */
     val correlationId: String? = null
 )

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
@@ -1,5 +1,7 @@
 package co.omisego.omisego.model.transaction.request
 
+import java.math.BigDecimal
+
 /*
  * OmiseGO
  *
@@ -27,7 +29,7 @@ data class TransactionRequestParams(
      * The amount of token to receive
      * This amount can be either inputted when generating or consuming a transaction request.
      */
-    val amount: Int? = null,
+    val amount: BigDecimal? = null,
 
     /**
      * The address specifying where the transaction should be sent to.

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
@@ -1,0 +1,15 @@
+package co.omisego.omisego.model.transaction.request
+
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 27/3/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+data class TransactionRequestCreateParams(
+    val type: TransactionRequestType = TransactionRequestType.RECEIVE,
+    val tokenId: String,
+    val amount: Int? = null,
+    val address: String? = null,
+    val correlationId: String? = null
+)

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
@@ -21,7 +21,7 @@ data class TransactionRequestCreateParams(
 
     /* The amount of token to receive
        This amount can be either inputted when generating or consuming a transaction request. */
-    val amount: Int? = null,
+    val amount: Double? = null,
 
     /* The address specifying where the transaction should be sent to.
        If not specified, the current user's primary address will be used. */

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
@@ -11,7 +11,7 @@ package co.omisego.omisego.model.transaction.request
  * Represents a structure used to generate a transaction request
  *
  */
-data class TransactionRequestCreateParams(
+data class TransactionRequestParams(
 
     /**
      * The type of transaction to be generated

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
@@ -13,20 +13,30 @@ package co.omisego.omisego.model.transaction.request
  */
 data class TransactionRequestCreateParams(
 
-    /* The type of transaction to be generated */
+    /**
+     * The type of transaction to be generated
+     */
     val type: TransactionRequestType = TransactionRequestType.RECEIVE,
 
-    /* The id of the desired token */
+    /**
+     * The id of the desired token
+     */
     val tokenId: String,
 
-    /* The amount of token to receive
-       This amount can be either inputted when generating or consuming a transaction request. */
+    /**
+     * The amount of token to receive
+     * This amount can be either inputted when generating or consuming a transaction request.
+     */
     val amount: Double? = null,
 
-    /* The address specifying where the transaction should be sent to.
-       If not specified, the current user's primary address will be used. */
+    /**
+     * The address specifying where the transaction should be sent to.
+     * If not specified, the current user's primary address will be used.
+     */
     val address: String? = null,
 
-    /* An id that can uniquely identify a transaction. Typically an order id from a provider. */
+    /**
+     * An id that can uniquely identify a transaction. Typically an order id from a provider.
+     */
     val correlationId: String? = null
 )

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
@@ -27,7 +27,7 @@ data class TransactionRequestParams(
      * The amount of token to receive
      * This amount can be either inputted when generating or consuming a transaction request.
      */
-    val amount: Double? = null,
+    val amount: Int? = null,
 
     /**
      * The address specifying where the transaction should be sent to.

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestType.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestType.kt
@@ -11,8 +11,13 @@ import co.omisego.omisego.constant.enums.OMGEnum
 import co.omisego.omisego.custom.gson.OMGEnumAdapter
 import com.google.gson.annotations.JsonAdapter
 
+/**
+ * The different types of request that can be generated
+ */
 @JsonAdapter(OMGEnumAdapter::class)
 enum class TransactionRequestType constructor(override val value: String) : OMGEnum {
+
+    /* The initiator wants to receive a specified token */
     RECEIVE("receive");
 
     override fun toString(): String = value

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestType.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestType.kt
@@ -1,0 +1,19 @@
+package co.omisego.omisego.model.transaction.request
+
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 27/3/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
+import co.omisego.omisego.constant.enums.OMGEnum
+import co.omisego.omisego.custom.gson.OMGEnumAdapter
+import com.google.gson.annotations.JsonAdapter
+
+@JsonAdapter(OMGEnumAdapter::class)
+enum class TransactionRequestType constructor(override val value: String) : OMGEnum {
+    RECEIVE("receive");
+
+    override fun toString(): String = value
+}

--- a/omisego-sdk/src/main/java/co/omisego/omisego/network/ewallet/EWalletAPI.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/network/ewallet/EWalletAPI.kt
@@ -7,6 +7,7 @@ package co.omisego.omisego.network.ewallet
  * Copyright © 2017-2018 OmiseGO. All rights reserved.
  */
 
+import co.omisego.omisego.constant.Endpoints.CREATE_TRANSACTION_REQUEST
 import co.omisego.omisego.constant.Endpoints.GET_CURRENT_USER
 import co.omisego.omisego.constant.Endpoints.GET_SETTINGS
 import co.omisego.omisego.constant.Endpoints.LIST_BALANCE
@@ -17,7 +18,11 @@ import co.omisego.omisego.model.BalanceList
 import co.omisego.omisego.model.Logout
 import co.omisego.omisego.model.Setting
 import co.omisego.omisego.model.User
-import co.omisego.omisego.model.transaction.TransactionListParams
+import co.omisego.omisego.model.pagination.PaginationList
+import co.omisego.omisego.model.transaction.list.Transaction
+import co.omisego.omisego.model.transaction.list.TransactionListParams
+import co.omisego.omisego.model.transaction.request.TransactionRequest
+import co.omisego.omisego.model.transaction.request.TransactionRequestCreateParams
 import retrofit2.http.Body
 import retrofit2.http.POST
 
@@ -36,4 +41,7 @@ interface EWalletAPI {
 
     @POST(LIST_TRANSACTIONS)
     fun listTransactions(@Body request: TransactionListParams): OMGCall<PaginationList<Transaction>>
+
+    @POST(CREATE_TRANSACTION_REQUEST)
+    fun createTransactionRequest(@Body request: TransactionRequestCreateParams): OMGCall<TransactionRequest>
 }

--- a/omisego-sdk/src/main/java/co/omisego/omisego/network/ewallet/EWalletAPI.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/network/ewallet/EWalletAPI.kt
@@ -19,10 +19,10 @@ import co.omisego.omisego.model.Logout
 import co.omisego.omisego.model.Setting
 import co.omisego.omisego.model.User
 import co.omisego.omisego.model.pagination.PaginationList
+import co.omisego.omisego.model.transaction.list.ListTransactionParams
 import co.omisego.omisego.model.transaction.list.Transaction
-import co.omisego.omisego.model.transaction.list.TransactionListParams
 import co.omisego.omisego.model.transaction.request.TransactionRequest
-import co.omisego.omisego.model.transaction.request.TransactionRequestCreateParams
+import co.omisego.omisego.model.transaction.request.TransactionRequestParams
 import retrofit2.http.Body
 import retrofit2.http.POST
 
@@ -40,8 +40,8 @@ interface EWalletAPI {
     fun getSettings(): OMGCall<Setting>
 
     @POST(LIST_TRANSACTIONS)
-    fun listTransactions(@Body request: TransactionListParams): OMGCall<PaginationList<Transaction>>
+    fun listTransactions(@Body request: ListTransactionParams): OMGCall<PaginationList<Transaction>>
 
     @POST(CREATE_TRANSACTION_REQUEST)
-    fun createTransactionRequest(@Body request: TransactionRequestCreateParams): OMGCall<TransactionRequest>
+    fun createTransactionRequest(@Body request: TransactionRequestParams): OMGCall<TransactionRequest>
 }

--- a/omisego-sdk/src/main/java/co/omisego/omisego/network/ewallet/EWalletClient.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/network/ewallet/EWalletClient.kt
@@ -113,6 +113,7 @@ class EWalletClient {
             /* Use a simple gson for now */
             val gson = GsonBuilder()
                     .registerTypeAdapter(ErrorCode::class.java, ErrorCodeDeserializer())
+                    .serializeNulls()
                     .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                     .create()
 

--- a/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/QRGenerator.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/QRGenerator.kt
@@ -7,6 +7,8 @@ package co.omisego.omisego.qrcode
  * Copyright © 2017-2018 OmiseGO. All rights reserved.
  */
 
+import android.graphics.Bitmap
+import co.omisego.omisego.model.transaction.request.TransactionRequest
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.MultiFormatWriter
 import com.google.zxing.WriterException
@@ -36,3 +38,11 @@ class QRGenerator(
     fun generate(payload: String, size: Int = DEFAULT_SIZE) =
         encoder.createBitmap(writer.encode(payload, BarcodeFormat.QR_CODE, size, size))
 }
+
+/**
+ * Generates an QR bitmap containing the encoded transaction request id
+ *
+ * @param size the desired image size
+ * @return An QR image if the transaction request was successfully encoded
+ */
+fun TransactionRequest.generateQRCode(size: Int = QRGenerator.DEFAULT_SIZE): Bitmap = QRGenerator().generate(id, size)

--- a/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/QRGenerator.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/QRGenerator.kt
@@ -1,0 +1,28 @@
+package co.omisego.omisego.qrcode
+
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 27/3/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.MultiFormatWriter
+import com.google.zxing.WriterException
+import com.journeyapps.barcodescanner.BarcodeEncoder
+
+class QRGenerator(
+    private val writer: MultiFormatWriter = MultiFormatWriter(),
+    private val encoder: BarcodeEncoder = BarcodeEncoder()
+) {
+    companion object {
+        const val DEFAULT_SIZE = 512
+    }
+
+    fun generate(transactionId: String, size: Int = DEFAULT_SIZE) = try {
+        encoder.createBitmap(writer.encode(transactionId, BarcodeFormat.QR_CODE, size, size))
+    } catch (e: WriterException) {
+        throw e
+    }
+}

--- a/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/QRGenerator.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/QRGenerator.kt
@@ -33,9 +33,6 @@ class QRGenerator(
      * @throws WriterException which may occur when encoding a QRCode
      * @return A QRCode bitmap
      */
-    fun generate(payload: String, size: Int = DEFAULT_SIZE) = try {
+    fun generate(payload: String, size: Int = DEFAULT_SIZE) =
         encoder.createBitmap(writer.encode(payload, BarcodeFormat.QR_CODE, size, size))
-    } catch (e: WriterException) {
-        throw e
-    }
 }

--- a/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/QRGenerator.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/QRGenerator.kt
@@ -12,16 +12,29 @@ import com.google.zxing.MultiFormatWriter
 import com.google.zxing.WriterException
 import com.journeyapps.barcodescanner.BarcodeEncoder
 
+/**
+ * For creating a QRCode bitmap
+ */
 class QRGenerator(
     private val writer: MultiFormatWriter = MultiFormatWriter(),
     private val encoder: BarcodeEncoder = BarcodeEncoder()
 ) {
     companion object {
+        /**
+         * The default size of QRCode bitmap in pixels [DEFAULT_SIZE x DEFAULT_SIZE]
+         */
         const val DEFAULT_SIZE = 512
     }
 
-    fun generate(transactionId: String, size: Int = DEFAULT_SIZE) = try {
-        encoder.createBitmap(writer.encode(transactionId, BarcodeFormat.QR_CODE, size, size))
+    /**
+     * Generate QRCode bitmap with the default size 512px
+     *
+     * @param payload the payload to include in the QRCode image
+     * @throws WriterException which may occur when encoding a QRCode
+     * @return A QRCode bitmap
+     */
+    fun generate(payload: String, size: Int = DEFAULT_SIZE) = try {
+        encoder.createBitmap(writer.encode(payload, BarcodeFormat.QR_CODE, size, size))
     } catch (e: WriterException) {
         throw e
     }

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/OMGAPIClientTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/OMGAPIClientTest.kt
@@ -140,6 +140,8 @@ class OMGAPIClientTest {
             transactionRequest
         )
 
+        Thread.sleep(100)
+
         verify(callback, times(1)).success(expected)
     }
 

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/OMGAPIClientTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/OMGAPIClientTest.kt
@@ -7,7 +7,6 @@ package co.omisego.omisego
  * Copyright © 2017-2018 OmiseGO. All rights reserved.
  */
 
-import co.omisego.omisego.constant.ErrorCode
 import co.omisego.omisego.constant.Versions
 import co.omisego.omisego.constant.enums.ErrorCode
 import co.omisego.omisego.custom.OMGCallback
@@ -21,6 +20,7 @@ import co.omisego.omisego.model.Setting
 import co.omisego.omisego.model.User
 import co.omisego.omisego.model.pagination.Pagination
 import co.omisego.omisego.model.pagination.PaginationList
+import co.omisego.omisego.model.transaction.list.Transaction
 import co.omisego.omisego.network.ewallet.EWalletClient
 import co.omisego.omisego.testUtils.GsonProvider
 import co.omisego.omisego.utils.OMGEncryptionHelper
@@ -106,12 +106,12 @@ class OMGAPIClientTest {
         val transactionList = gson.fromJson<List<Transaction>>(data, object : TypeToken<List<Transaction>>() {}.type)
 
         val expected = OMGResponse(
-                Versions.EWALLET_API,
-                true,
-                PaginationList(
-                        transactionList,
-                        Pagination(10, true, true, 1)
-                )
+            Versions.EWALLET_API,
+            true,
+            PaginationList(
+                transactionList,
+                Pagination(10, true, true, 1)
+            )
         )
 
         Thread.sleep(100)

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/OMGAPIClientTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/OMGAPIClientTest.kt
@@ -21,6 +21,7 @@ import co.omisego.omisego.model.User
 import co.omisego.omisego.model.pagination.Pagination
 import co.omisego.omisego.model.pagination.PaginationList
 import co.omisego.omisego.model.transaction.list.Transaction
+import co.omisego.omisego.model.transaction.request.TransactionRequest
 import co.omisego.omisego.network.ewallet.EWalletClient
 import co.omisego.omisego.testUtils.GsonProvider
 import co.omisego.omisego.utils.OMGEncryptionHelper
@@ -50,6 +51,7 @@ class OMGAPIClientTest {
     private val userFile: File by ResourceFile("user.me-post.json")
     private val listBalanceFile: File by ResourceFile("me.list_balances-post.json")
     private val listTransactionsFile: File by ResourceFile("me.list_transactions-post.json")
+    private val createTransactionRequestFile: File by ResourceFile("me.create_transaction_request-post.json")
     private val getSettingFile: File by ResourceFile("me.get_settings-post.json")
     private val errorFile: File by ResourceFile("fail.client-invalid_auth_scheme.json")
     private val gson by lazy { GsonProvider.provide() }
@@ -120,6 +122,28 @@ class OMGAPIClientTest {
     }
 
     @Test
+    fun `OMGAPIClient should call create_transaction_request successfully`() {
+        val element = gson.fromJson(createTransactionRequestFile.readText(), JsonElement::class.java)
+        val result = Response.success(element)
+        createTransactionRequestFile.mockEnqueueWithHttpCode(mockWebServer)
+
+        val callback: OMGCallback<TransactionRequest> = mock()
+
+        omgAPIClient.createTransactionRequest(mock()).enqueue(callback)
+
+        val data = result.body()!!.asJsonObject.getAsJsonObject("data")
+        val transactionRequest = gson.fromJson<TransactionRequest>(data, object : TypeToken<TransactionRequest>() {}.type)
+
+        val expected = OMGResponse(
+            Versions.EWALLET_API,
+            true,
+            transactionRequest
+        )
+
+        verify(callback, times(1)).success(expected)
+    }
+
+    @Test
     fun `OMGAPIClient should call get_current_user and success`() {
         val element = gson.fromJson(userFile.readText(), JsonElement::class.java)
         val result = Response.success(element)
@@ -173,7 +197,6 @@ class OMGAPIClientTest {
             userFile.readText(),
             object : TypeToken<OMGResponse<User>>() {}.type
         )
-
         userFile.mockEnqueueWithHttpCode(mockWebServer)
 
         val response = omgAPIClient.getCurrentUser().execute()

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/TransactionListParamsTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/TransactionListParamsTest.kt
@@ -10,7 +10,7 @@ package co.omisego.omisego.model.transaction
 import co.omisego.omisego.model.pagination.Paginable.Transaction.SearchableFields
 import co.omisego.omisego.model.pagination.Paginable.Transaction.SortableFields
 import co.omisego.omisego.model.pagination.SortDirection
-import co.omisego.omisego.model.transaction.list.TransactionListParams
+import co.omisego.omisego.model.transaction.list.ListTransactionParams
 import com.google.gson.FieldNamingPolicy
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
@@ -18,18 +18,18 @@ import org.amshove.kluent.shouldEqual
 import org.junit.Before
 import kotlin.test.Test
 
-class TransactionListParamsTest {
+class ListTransactionParamsTest {
     private lateinit var gson: Gson
     @Before
     fun setUp() {
         gson = GsonBuilder()
-                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                .create()
+            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+            .create()
     }
 
     @Test
-    fun `TransactionListParams should be added successfully`() {
-        val transactionListParams = TransactionListParams(1,
+    fun `ListTransactionParams should be added successfully`() {
+        val transactionListParams = ListTransactionParams(1,
             10,
             SortableFields.FROM,
             SortDirection.ASCENDING,

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/TransactionListParamsTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/TransactionListParamsTest.kt
@@ -10,6 +10,7 @@ package co.omisego.omisego.model.transaction
 import co.omisego.omisego.model.pagination.Paginable.Transaction.SearchableFields
 import co.omisego.omisego.model.pagination.Paginable.Transaction.SortableFields
 import co.omisego.omisego.model.pagination.SortDirection
+import co.omisego.omisego.model.transaction.list.TransactionListParams
 import com.google.gson.FieldNamingPolicy
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
@@ -29,12 +30,12 @@ class TransactionListParamsTest {
     @Test
     fun `TransactionListParams should be added successfully`() {
         val transactionListParams = TransactionListParams(1,
-                10,
-                SortableFields.FROM,
-                SortDirection.ASCENDING,
-                "test",
-                mapOf(SearchableFields.STATUS to "completed", SearchableFields.ID to "1234"),
-                "address:1234"
+            10,
+            SortableFields.FROM,
+            SortDirection.ASCENDING,
+            "test",
+            mapOf(SearchableFields.STATUS to "completed", SearchableFields.ID to "1234"),
+            "address:1234"
         )
 
         val expected = """

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/network/ewallet/EWalletClientTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/network/ewallet/EWalletClientTest.kt
@@ -9,22 +9,18 @@ package co.omisego.omisego.network.ewallet
  */
 
 import co.omisego.omisego.constant.Endpoints
-import co.omisego.omisego.constant.ErrorCode
 import co.omisego.omisego.constant.Exceptions
 import co.omisego.omisego.constant.HTTPHeaders
 import co.omisego.omisego.constant.Versions
-import co.omisego.omisego.custom.gson.ErrorCodeDeserializer
 import co.omisego.omisego.extension.mockEnqueueWithHttpCode
 import co.omisego.omisego.helpers.delegation.ResourceFile
 import co.omisego.omisego.model.BalanceList
 import co.omisego.omisego.model.OMGResponse
 import co.omisego.omisego.model.Setting
 import co.omisego.omisego.model.User
-import co.omisego.omisego.utils.OMGEncryptionHelper
-import co.omisego.omisego.model.transaction.TransactionListParams
+import co.omisego.omisego.model.transaction.list.TransactionListParams
 import co.omisego.omisego.testUtils.GsonProvider
-import com.google.gson.FieldNamingPolicy
-import com.google.gson.GsonBuilder
+import co.omisego.omisego.utils.OMGEncryptionHelper
 import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockWebServer
 import org.amshove.kluent.mock
@@ -55,8 +51,8 @@ class EWalletClientTest {
     @Before
     fun setUp() {
         val auth = OMGEncryptionHelper.encryptBase64(
-                secret.getString("api_key"),
-                secret.getString("auth_token")
+            secret.getString("api_key"),
+            secret.getString("auth_token")
         )
 
         eWalletClient = EWalletClient.Builder {
@@ -127,8 +123,8 @@ class EWalletClientTest {
     fun `EWalletClient should be set the header correctly`() {
         userFile.mockEnqueueWithHttpCode(mockWebServer)
         val expectedAuth = "OMGClient ${OMGEncryptionHelper.encryptBase64(
-                secret.getString("api_key"),
-                secret.getString("auth_token")
+            secret.getString("api_key"),
+            secret.getString("auth_token")
         )}"
 
         eWalletClient.eWalletAPI.getCurrentUser().execute()

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/network/ewallet/EWalletClientTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/network/ewallet/EWalletClientTest.kt
@@ -18,7 +18,7 @@ import co.omisego.omisego.model.BalanceList
 import co.omisego.omisego.model.OMGResponse
 import co.omisego.omisego.model.Setting
 import co.omisego.omisego.model.User
-import co.omisego.omisego.model.transaction.list.TransactionListParams
+import co.omisego.omisego.model.transaction.list.ListTransactionParams
 import co.omisego.omisego.testUtils.GsonProvider
 import co.omisego.omisego.utils.OMGEncryptionHelper
 import okhttp3.HttpUrl
@@ -165,7 +165,7 @@ class EWalletClientTest {
     fun `EWalletClient request to list_transactions with the correct path`() {
         listTransactionsFile.mockEnqueueWithHttpCode(mockWebServer)
 
-        val listTransactionParams: TransactionListParams = mock()
+        val listTransactionParams: ListTransactionParams = mock()
 
         eWalletClient.eWalletAPI.listTransactions(listTransactionParams).execute()
         val request = mockWebServer.takeRequest()

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/qrcode/QRGeneratorTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/qrcode/QRGeneratorTest.kt
@@ -1,0 +1,66 @@
+package co.omisego.omisego.qrcode
+
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.MultiFormatReader
+import com.google.zxing.RGBLuminanceSource
+import com.google.zxing.common.HybridBinarizer
+import org.amshove.kluent.shouldEqualTo
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 28/3/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
+@RunWith(RobolectricTestRunner::class)
+class QRGeneratorTest {
+    @Rule
+    @JvmField
+    val expectedEx = ExpectedException.none()!!
+    private val qrGenerator by lazy { QRGenerator() }
+    private val expectedSize: Int = 200
+    private val expectedPayload = "Hello World"
+
+    @Test
+    fun `QRGenerator should generate QR image with the correct size`() {
+        val bitmap = qrGenerator.generate(expectedPayload, expectedSize)
+
+        bitmap.width shouldEqualTo expectedSize
+        bitmap.height shouldEqualTo expectedSize
+    }
+
+    @Test
+    fun `QRGenerator should throw IllegalArgumentException if the payload is empty`() {
+        expectedEx.expect(IllegalArgumentException::class.java)
+        expectedEx.expectMessage("Found empty contents")
+
+        qrGenerator.generate("", expectedSize)
+    }
+
+    @Test
+    fun `QRGenerator should encode payload correctly`() {
+        /* Retrieve the generated QR image with payload "Hello World" */
+        val qrBitmap = qrGenerator.generate(expectedPayload, expectedSize)
+
+        /* Initial pixels with length = total pixels of qrBitmap */
+        val bitmapPixels = IntArray(qrBitmap.width * qrBitmap.height)
+
+        /* Copy all pixels from the qrBitmap to the bitmapPixels */
+        qrBitmap.getPixels(bitmapPixels, 0, expectedSize, 0, 0, expectedSize, expectedSize)
+
+        val source = RGBLuminanceSource(expectedSize, expectedSize, bitmapPixels)
+        val binaryBitmap = BinaryBitmap(HybridBinarizer(source))
+
+        /* Decode the result from the QR bitmap */
+        val result = MultiFormatReader().decode(binaryBitmap)
+
+        /* Validate that result payload should be equal to "Hello World" */
+        result.text shouldEqualTo expectedPayload
+    }
+}

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/qrcode/QRGeneratorTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/qrcode/QRGeneratorTest.kt
@@ -1,5 +1,12 @@
 package co.omisego.omisego.qrcode
 
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 28/3/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
 import com.google.zxing.BinaryBitmap
 import com.google.zxing.MultiFormatReader
 import com.google.zxing.RGBLuminanceSource
@@ -10,13 +17,6 @@ import org.junit.Test
 import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-
-/*
- * OmiseGO
- *
- * Created by Phuchit Sirimongkolsathien on 28/3/2018 AD.
- * Copyright © 2017-2018 OmiseGO. All rights reserved.
- */
 
 @RunWith(RobolectricTestRunner::class)
 class QRGeneratorTest {

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/qrcode/QRGeneratorTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/qrcode/QRGeneratorTest.kt
@@ -17,8 +17,10 @@ import org.junit.Test
 import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [21])
 class QRGeneratorTest {
     @Rule
     @JvmField

--- a/omisego-sdk/src/test/resources/me.create_transaction_request-post.json
+++ b/omisego-sdk/src/test/resources/me.create_transaction_request-post.json
@@ -1,0 +1,29 @@
+{
+  "version": "1",
+  "success": true,
+  "data": {
+    "user_id": "a9a8382c-f47f-481a-88d2-780584e77b6e",
+    "updated_at": "2018-03-28T04:40:30.213016Z",
+    "type": "receive",
+    "status": "valid",
+    "object": "transaction_request",
+    "minted_token_id": "OMG:20f18fe9-3354-4ef8-9853-226f633a4ef2",
+    "minted_token": {
+      "updated_at": "2018-03-14T09:42:17.267266Z",
+      "symbol": "OMG",
+      "subunit_to_unit": 10000,
+      "object": "minted_token",
+      "name": "OmiseGO",
+      "metadata": {},
+      "id": "OMG:20f18fe9-3354-4ef8-9853-226f633a4ef2",
+      "encrypted_metadata": {},
+      "created_at": "2018-03-14T09:42:17.267256Z"
+    },
+    "id": "1deb8d7c-519f-4f8c-aa8a-8ab2a682bbad",
+    "created_at": "2018-03-28T04:40:29.997757Z",
+    "correlation_id": null,
+    "amount": 100,
+    "address": "dec1342d-d76b-4f78-bfe6-3f9aa984a822",
+    "account_id": null
+  }
+}


### PR DESCRIPTION
Issue/Task Number: `165-implement-qr-code-transaction-request-on-android-sdk`

# Overview

Add transaction request functionality and ability to show the QR code to the SDK

<p align="center">
  <img src="https://user-images.githubusercontent.com/4509570/37962597-d9536fa8-31e5-11e8-9809-f40328aec16d.png">
</p>

Any QR code scanner scan this QR image will get the `id` of the generated `TransactionRequest`

# Changes

- Implement transaction request (`/me.create_transaction_request`)
- Implement QR code generator to create QR code `Bitmap`

# Implementation Details

1. Add dependency `com.journeyapps:zxing-android-embedded:3.2.0` (an android port of `ZXing` library).
> Note: Android don't have any native QR code generation API, so I used the based library that most of QR code library built on top it. It's [ZXing (Zebra Crossing)](https://github.com/zxing/zxing) library developed and maintained by Google.

2. Add an endpoint `me.create_transaction_request` in the `EwalletAPI`

3. Create `TransactionRequestParams` to use for creating an object to send to the API.

4. Create `TransactionRequest` to represent the response from the API.

5. Create `QRCodeGenerator` to create the QR code image using `string` payload.

6. Add extension for `TransactionRequest` to conveniently create the QR code bitmap.

# Usage

```kotlin
val request = TransactionRequestCreateParams(
    type = TransactionRequestType.RECEIVE,
    tokenId = "a_token_id",
    amount = 10.24
    address = "receiver_address"
    correlationId = "correlation_id"
)

omgAPIClient.generateTransactionRequest(request).enqueue(object : OMGCallback<TransactionRequest> {
    override fun success(response: OMGResponse<TransactionRequest>) {
        //TODO: Do something with the transaction request (get the QR code representation for example)
        val qrBitmap = response.data.generateQRCode(512)) // Generate the QR bitmap
    }

    override fun fail(response: OMGResponse<APIError>) {
        //TODO: Handle the error
    }
})
```

# Impact

`N/A`

# Todo

- [x] Finish writing test