### PR TITLE
Removed updatedAt from the Transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and `OmiseGO` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.9.4] - 2018-05-xx
+### Added
+- [Websocket](https://github.com/omisego/android-sdk#websocket)
+
+### Changed
+- Renamed `EncryptionHelper` to `OMGEncryption`. Now, it can be only used for create an authorization header for connecting to the eWallet API.
+- Changed the initialization steps of the `EWalletClient` from passing the base64 encrypted of "apiKey:authorizationToken" to pass both `apiKey` and `authenticationToken` to prevent misconfiguration.
+- Removed `updatedAt` field from the `Transaction`
+
 ## [0.9.3] - 2018-05-11
 ### Added
 - [Kotlin linter](https://github.com/shyiko/ktlint)
@@ -31,6 +40,7 @@ and `OmiseGO` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Logout the current user
 - [OMGKeyManager - encryption and decryption helpers](https://github.com/omisego/android-sdk/pull/11)
 
-[Unreleased]: https://github.com/omisego/android-sdk/compare/v0.9.3...HEAD
+[Unreleased]: https://github.com/omisego/android-sdk/compare/v0.9.4...HEAD
+[0.9.4]: https://github.com/omisego/android-sdk/compare/v0.9.4...v0.9.3
 [0.9.3]: https://github.com/omisego/android-sdk/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/omisego/android-sdk/compare/v0.9.1...v0.9.2

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Where
 * `perPage` is the number of results per page
 * `sortBy` is the sorting field. The available values are:
 
-    `ID`, `STATUS`, `FROM`, `TO`, `CREATED_AT`, `UPDATED_AT`
+    `ID`, `STATUS`, `FROM`, `TO`, `CREATED_AT`
     
     > `import co.omisego.omisego.model.pagination.Paginable.Transaction.SortableFields.*`
     
@@ -169,7 +169,7 @@ Where
 * `searchTerm` *(optional)* is a term to search for all of the searchable fields. 
       Conflict with `searchTerms`, only use one of them. The available values are:
     
-    `ID`, `STATUS`, `FROM`, `TO`, `CREATED_AT`, `UPDATED_AT`
+    `ID`, `STATUS`, `FROM`, `TO`,
       
     > `import co.omisego.omisego.model.pagination.Paginable.Transaction.SearchableFields.*`
     

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/list/Transaction.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/list/Transaction.kt
@@ -27,6 +27,6 @@ data class Transaction(
     val to: TransactionSource,
     val exchange: TransactionExchange,
     val metadata: Map<String, Any>,
-    val createdAt: Date,
-    val updatedAt: Date
+    val encryptedMetadata: Map<String, Any>,
+    val createdAt: Date
 ) : Paginable.Transaction()

--- a/omisego-sdk/src/test/resources/me.create_transaction_request-post.json
+++ b/omisego-sdk/src/test/resources/me.create_transaction_request-post.json
@@ -3,7 +3,6 @@
   "success": true,
   "data": {
     "user_id": "a9a8382c-f47f-481a-88d2-780584e77b6e",
-    "updated_at": "2018-03-28T04:40:30.213016Z",
     "type": "receive",
     "status": "valid",
     "object": "transaction_request",

--- a/omisego-sdk/src/test/resources/me.list_transactions-post.json
+++ b/omisego-sdk/src/test/resources/me.list_transactions-post.json
@@ -11,7 +11,6 @@
     "object": "list",
     "data": [
       {
-        "updated_at": "2018-03-14T10:07:57.580212Z",
         "to": {
           "object": "transaction_source",
           "minted_token": {
@@ -57,7 +56,6 @@
         "created_at": "2018-03-14T10:07:57.202080Z"
       },
       {
-        "updated_at": "2018-03-14T10:16:11.491819Z",
         "to": {
           "object": "transaction_source",
           "minted_token": {
@@ -103,7 +101,6 @@
         "created_at": "2018-03-14T10:16:11.444569Z"
       },
       {
-        "updated_at": "2018-03-14T10:19:22.560746Z",
         "to": {
           "object": "transaction_source",
           "minted_token": {
@@ -149,7 +146,6 @@
         "created_at": "2018-03-14T10:19:22.520718Z"
       },
       {
-        "updated_at": "2018-03-14T10:19:36.469182Z",
         "to": {
           "object": "transaction_source",
           "minted_token": {
@@ -195,7 +191,6 @@
         "created_at": "2018-03-14T10:19:36.433334Z"
       },
       {
-        "updated_at": "2018-03-14T10:21:30.087141Z",
         "to": {
           "object": "transaction_source",
           "minted_token": {
@@ -241,7 +236,6 @@
         "created_at": "2018-03-14T10:21:30.024036Z"
       },
       {
-        "updated_at": "2018-03-14T10:40:59.359332Z",
         "to": {
           "object": "transaction_source",
           "minted_token": {
@@ -287,7 +281,6 @@
         "created_at": "2018-03-14T10:40:59.310651Z"
       },
       {
-        "updated_at": "2018-03-14T10:41:16.205825Z",
         "to": {
           "object": "transaction_source",
           "minted_token": {
@@ -333,7 +326,6 @@
         "created_at": "2018-03-14T10:41:16.165945Z"
       },
       {
-        "updated_at": "2018-03-14T10:42:03.066812Z",
         "to": {
           "object": "transaction_source",
           "minted_token": {
@@ -379,7 +371,6 @@
         "created_at": "2018-03-14T10:42:03.008787Z"
       },
       {
-        "updated_at": "2018-03-14T10:42:21.982037Z",
         "to": {
           "object": "transaction_source",
           "minted_token": {


### PR DESCRIPTION
Issue/Task Number: `283-remove-updatedat-from-transaction`

# Overview

This PR removes `updatedAt` attribute from the `Transaction` and also its related uses.

# Changes

* Remove `updatedAt` attribute from `Transaction` model
* Update the sort/filter terms of `Transaction`

# Implementation Details

`Transaction` can't be updated so there is no need for the `updatedAt` attribute.

# Usage

Describe how to test your new feature/bug fix. Step by step so we can quickly give it a try.

# Impact

Once removed from the API, older version of the SDK will not work anymore.