### PR TITLE
Add account and avatar model

### DIFF
--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/Account.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/Account.kt
@@ -1,0 +1,37 @@
+package co.omisego.omisego.model
+
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 25/5/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
+import java.util.Date
+
+/**
+ * Represents an account.
+ *
+ * @param id The unique identifier of the account.
+ * @param parentId The id of the parent account.
+ * @param name The name of the account.
+ * @param description The description of the account.
+ * @param isMaster A boolean indicating if the account is a master account or not.
+ * @param avatar The avatar object containing urls.
+ * @param metadata Any additional metadata that need to be stored as a dictionary.
+ * @param encryptedMetadata Any additional encrypted metadata that need to be stored as a dictionary.
+ * @param createdAt The creation date of the account.
+ * @param updatedAt The date when the account was last updated.
+ */
+data class Account(
+    val id: String,
+    val parentId: String,
+    val name: String,
+    val description: String,
+    val isMaster: Boolean,
+    val avatar: Avatar,
+    val metadata: Map<String, Any>,
+    val encryptedMetadata: Map<String, Any>,
+    val createdAt: Date,
+    val updatedAt: Date
+)

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/Avatar.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/Avatar.kt
@@ -1,0 +1,23 @@
+package co.omisego.omisego.model
+
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 25/5/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
+/**
+ * Represents an avatar containing urls of different sizes.
+ *
+ * @param original The url of the original image.
+ * @param large The url of the large image.
+ * @param small The url of the small image.
+ * @param thumbnail The url of the thumbnail image.
+ */
+data class Avatar(
+    val original: String,
+    val large: String,
+    val small: String,
+    val thumbnail: String
+)


### PR DESCRIPTION
Issue/Task Number: `344-add-account-and-avatar-model`

# Overview

This PR adds `Avatar` and  `Account` model to the SDK.

# Changes

- Added Avatar
- Added Account

# Implementation Details

`N/A`

# Usage

`N/A`

# Impact

`N/A`