### PR TITLE
Implement me.transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and `OmiseGO` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.9.4] - 2018-05-xx
 ### Added
 - [Websocket](https://github.com/omisego/android-sdk#websocket)
+- [Transfer](https://github.com/omisego/android-sdk#send-tokens-to-an-address)
 
 ### Changed
 - Renamed `EncryptionHelper` to `OMGEncryption`. Now, it can be only used for create an authorization header for connecting to the eWallet API.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 The [OmiseGO](https://omisego.network) Android SDK allows developers to easily interact with a node of the OmiseGO eWallet.
 
-
 # Table of Contents
 
 - [Requirements](#requirements)
@@ -15,6 +14,7 @@ The [OmiseGO](https://omisego.network) Android SDK allows developers to easily i
     - [Get the provider settings](#get-the-provider-settings)
     - [Get the current user's transactions](#get-the-current-users-transactions)
   - [Transferring tokens](#transferring-tokens)
+    - [Send tokens to an address](#send-tokens-to-an-address)
     - [Generate a transaction request](#generate-a-transaction-request)
     - [Consume a transaction request](#consume-a-transaction-request)
     - [Approve or Reject a transaction consumption](#approve-or-reject-a-transaction-consumption)
@@ -209,9 +209,39 @@ Where:
     * `isLastPage` is a bool indicating if the page received is the last page
 
 ## Transferring tokens
-In order to transfer tokens between 2 addresses, the SDK offers the possibility to generate and consume transaction requests. To make a transaction happen, a `TransactionRequest` needs to be created and consumed by a `TransactionConsumption`.
 
-### Generation
+The SDK offers 2 ways for transferring tokens between addresses:
+- A simple one way transfer from one of the current user's wallets to an address.
+- A highly configurable send/receive mechanism in 2 steps using transaction requests.
+
+#### Send tokens to an address
+
+The most basic way to transfer tokens is to use the `omgAPIClient.transfer()` method, which allows the current user to send tokens from one of its wallet to a specific address.
+
+```kotlin
+val request = TransactionSendParams(
+    from = "1e3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+    to = "2e3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+    amount = 1000.bd,
+    tokenId =  "BTC:xe3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
+)
+
+omgAPIClient.transfer(request).enqueue(object : OMGCallback<Transaction>{
+    override fun success(response: OMGResponse<Transaction>) {
+        // Do something
+    }
+
+    override fun fail(response: OMGResponse<APIError>) {
+        // Handle error
+    }
+})
+```
+
+### Generate a transaction request
+
+A more configurable way to transfer tokens between 2 addresses is to use the transaction request flow.
+To make a transaction happen, a `TransactionRequest` needs to be created and consumed by a `TransactionConsumption`.
+
 To generate a new transaction request you can call:
 
 ```kotlin

--- a/omisego-sdk/src/main/java/co/omisego/omisego/OMGAPIClient.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/OMGAPIClient.kt
@@ -15,6 +15,7 @@ import co.omisego.omisego.model.transaction.consumption.TransactionConsumptionPa
 import co.omisego.omisego.model.transaction.list.TransactionListParams
 import co.omisego.omisego.model.transaction.request.TransactionRequestCreateParams
 import co.omisego.omisego.model.transaction.request.TransactionRequestParams
+import co.omisego.omisego.model.transaction.send.TransactionSendParam
 import co.omisego.omisego.network.ewallet.EWalletClient
 
 /**
@@ -139,10 +140,19 @@ class OMGAPIClient(private val eWalletClient: EWalletClient) {
      * Asynchronously reject the transaction consumption from the given [TransactionConsumptionActionParams] object
      * if *success* the [OMGCallback<TransactionConsumption>] will be invoked with the [co.omisego.omisego.model.transaction.consumption.TransactionConsumption] parameter,
      * if *fail* the [OMGCallback<TransactionConsumption>] will be invoked with the [co.omisego.omisego.model.APIError] parameter.
+     *
      * @param request The TransactionConsumptionActionParams object containing the transaction consumption id to be rejected.
      */
     fun rejectTransactionConsumption(request: TransactionConsumptionActionParams) =
         eWalletAPI.rejectTransactionConsumption(request)
+
+    /**
+     * Send tokens to an address
+     *
+     * @param request The TransactionSendParams object to customize the transaction
+     */
+    fun transfer(request: TransactionSendParam) =
+        eWalletAPI.transfer(request)
 
     /**
      * Set new [authenticationToken].

--- a/omisego-sdk/src/main/java/co/omisego/omisego/constant/Endpoints.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/constant/Endpoints.kt
@@ -17,5 +17,6 @@ object Endpoints {
     const val CONSUME_TRANSACTION_REQUEST = "me.consume_transaction_request"
     const val APPROVE_TRANSACTION = "me.approve_transaction_consumption"
     const val REJECT_TRANSACTION = "me.reject_transaction_consumption"
+    const val TRANSFER = "me.transfer"
     const val GET_SETTINGS = "me.get_settings"
 }

--- a/omisego-sdk/src/main/java/co/omisego/omisego/constant/enums/ErrorCode.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/constant/enums/ErrorCode.kt
@@ -26,6 +26,8 @@ enum class ErrorCode constructor(private val code: String) {
     //Error code from OmiseGO user API
     USER_ACCESS_TOKEN_EXPIRED("user:access_token_expired"),
     USER_ACCESS_TOKEN_NOT_FOUND("user:access_token_not_found"),
+    USER_FROM_ADDRESS_NOT_FOUND("user:from_address_not_found"),
+    USER_FROM_ADDRESS_MISMATCH("user:from_address_mismatch"),
 
     // Error code from OmiseGO SDK itself
     SDK_NETWORK_ERROR("sdk:network_error"),

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/send/TransactionSendParam.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/send/TransactionSendParam.kt
@@ -11,7 +11,7 @@ package co.omisego.omisego.model.transaction.send
  * Represents a structure used to create a transaction
  *
  * @param from The address from which to take the tokens (which must belong to the user).
- * If not specified, the user's primary balance will be used.
+ * If not specified, the user's primary address will be used.
  * @param to The address where to send the tokens.
  * @param amount The amount of minted token to transfer (down to subunit to unit).
  * @param tokenId The id of the minted token to send.

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/send/TransactionSendParam.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/send/TransactionSendParam.kt
@@ -1,0 +1,28 @@
+package co.omisego.omisego.model.transaction.send
+
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 7/6/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
+/**
+ * Represents a structure used to create a transaction
+ *
+ * @param from The address from which to take the tokens (which must belong to the user).
+ * If not specified, the user's primary balance will be used.
+ * @param to The address where to send the tokens.
+ * @param amount The amount of minted token to transfer (down to subunit to unit).
+ * @param tokenId The id of the minted token to send.
+ * @param metadata Additional metadata for the transaction.
+ * @param encryptedMetadata Additional encrypted metadata for the transaction.
+ */
+data class TransactionSendParam(
+    val from: String?,
+    val to: String,
+    val amount: Double,
+    val tokenId: String,
+    val metadata: Map<String, Any>,
+    val encryptedMetadata: Map<String, Any>
+)

--- a/omisego-sdk/src/main/java/co/omisego/omisego/network/ewallet/EWalletAPI.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/network/ewallet/EWalletAPI.kt
@@ -7,8 +7,8 @@ package co.omisego.omisego.network.ewallet
  * Copyright © 2017-2018 OmiseGO. All rights reserved.
  */
 
-import co.omisego.omisego.constant.Endpoints.CONSUME_TRANSACTION_REQUEST
 import co.omisego.omisego.constant.Endpoints.APPROVE_TRANSACTION
+import co.omisego.omisego.constant.Endpoints.CONSUME_TRANSACTION_REQUEST
 import co.omisego.omisego.constant.Endpoints.CREATE_TRANSACTION_REQUEST
 import co.omisego.omisego.constant.Endpoints.GET_CURRENT_USER
 import co.omisego.omisego.constant.Endpoints.GET_SETTINGS
@@ -17,20 +17,22 @@ import co.omisego.omisego.constant.Endpoints.LIST_TRANSACTIONS
 import co.omisego.omisego.constant.Endpoints.LOGOUT
 import co.omisego.omisego.constant.Endpoints.REJECT_TRANSACTION
 import co.omisego.omisego.constant.Endpoints.RETRIEVE_TRANSACTION_REQUEST
+import co.omisego.omisego.constant.Endpoints.TRANSFER
 import co.omisego.omisego.custom.retrofit2.adapter.OMGCall
 import co.omisego.omisego.model.BalanceList
 import co.omisego.omisego.model.Logout
 import co.omisego.omisego.model.Setting
 import co.omisego.omisego.model.User
 import co.omisego.omisego.model.pagination.PaginationList
-import co.omisego.omisego.model.transaction.consumption.TransactionConsumptionActionParams
 import co.omisego.omisego.model.transaction.consumption.TransactionConsumption
+import co.omisego.omisego.model.transaction.consumption.TransactionConsumptionActionParams
 import co.omisego.omisego.model.transaction.consumption.TransactionConsumptionParams
 import co.omisego.omisego.model.transaction.list.Transaction
 import co.omisego.omisego.model.transaction.list.TransactionListParams
 import co.omisego.omisego.model.transaction.request.TransactionRequest
 import co.omisego.omisego.model.transaction.request.TransactionRequestCreateParams
 import co.omisego.omisego.model.transaction.request.TransactionRequestParams
+import co.omisego.omisego.model.transaction.send.TransactionSendParam
 import retrofit2.http.Body
 import retrofit2.http.Header
 import retrofit2.http.POST
@@ -72,4 +74,9 @@ interface EWalletAPI {
     fun rejectTransactionConsumption(
         @Body request: TransactionConsumptionActionParams
     ): OMGCall<TransactionConsumption>
+
+    @POST(TRANSFER)
+    fun transfer(
+        @Body request: TransactionSendParam
+    ): OMGCall<Transaction>
 }

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/constant/ErrorCodeTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/constant/ErrorCodeTest.kt
@@ -40,6 +40,8 @@ class ErrorCodeTest {
                 "server:unknown_error" -> ErrorCode.SERVER_UNKNOWN_ERROR
                 "user:access_token_not_found" -> ErrorCode.USER_ACCESS_TOKEN_NOT_FOUND
                 "user:access_token_expired" -> ErrorCode.USER_ACCESS_TOKEN_EXPIRED
+                "user:from_address_not_found" -> ErrorCode.USER_FROM_ADDRESS_NOT_FOUND
+                "user:from_address_mismatch" -> ErrorCode.USER_FROM_ADDRESS_MISMATCH
                 "sdk:network_error" -> ErrorCode.SDK_NETWORK_ERROR
                 "sdk:parse_error" -> ErrorCode.SDK_PARSE_ERROR
                 "sdk:unknown_error" -> ErrorCode.SDK_UNEXPECTED_ERROR

--- a/omisego-sdk/src/test/resources/transaction.json
+++ b/omisego-sdk/src/test/resources/transaction.json
@@ -1,0 +1,48 @@
+{
+  "version": "1",
+  "success": true,
+  "data": {
+    "object": "transaction",
+    "id": "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+    "from": {
+      "object": "transaction_source",
+      "address": "1e3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+      "amount": 1000,
+      "minted_token": {
+        "object": "minted_token",
+        "id": "BTC:xe3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+        "symbol": "BTC",
+        "name": "Bitcoin",
+        "subunit_to_unit": 100,
+        "metadata": {},
+        "encrypted_metadata": {},
+        "created_at": "2018-01-01T00:00:00Z",
+        "updated_at": "2018-01-01T00:00:00Z"
+      }
+    },
+    "to": {
+      "object": "transaction_source",
+      "address": "2e3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+      "amount": 1000,
+      "minted_token": {
+        "object": "minted_token",
+        "id": "BTC:xe3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+        "symbol": "BTC",
+        "name": "Bitcoin",
+        "subunit_to_unit": 100,
+        "metadata": {},
+        "encrypted_metadata": {},
+        "created_at": "2018-01-01T00:00:00Z",
+        "updated_at": "2018-01-01T00:00:00Z"
+      }
+    },
+    "exchange": {
+      "object": "exchange",
+      "rate": 1
+    },
+    "status": "confirmed",
+    "metadata": {},
+    "encrypted_metadata": {},
+    "created_at": "2018-01-01T00:00:00Z"
+  }
+}


### PR DESCRIPTION
Issue/Task Number: `328-implement-me-transfer`

# Overview

This PR adds the `me.transfer` endpoint to allow a user to make a transfer to the other user (address).

# Changes

`N/A`

# Implementation Details

1. Add new endpoint `me.transfer`

2. Create model `TransferSendParam`

3. Add more endpoint to interface `EWalletAPI`

4. Implement `me.transfer` in `OMGAPIClient`

5. Implement test simulating a call to `me.transfer` and verify parsing is successful.

# Usage

```kotlin
val request = TransactionSendParams(
    from = "1e3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
    to = "2e3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
    amount = 1000.bd,
    tokenId =  "BTC:xe3982f5-4a27-498d-a91b-7bb2e2a8d3d1"
)

omgAPIClient.transfer(request).enqueue(object : OMGCallback<Transaction>{
    override fun success(response: OMGResponse<Transaction>) {
        // Do something
    }

    override fun fail(response: OMGResponse<APIError>) {
        // Handle error
    }
})
```

# Impact

`N/A`