### PR TITLE
Implement formatted id 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and `OmiseGO` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Changed the initialization steps of the `EWalletClient` from passing the base64 encrypted of "apiKey:authorizationToken" to pass both `apiKey` and `authenticationToken` to prevent misconfiguration.
 - Removed `updatedAt` field from the `Transaction`
 - Rename `MintedToken` to `Token`.
+- Changed `retrieveTransactionRequest` API parameter to pass `formattedId` instead of `id`
 
 ## [0.9.3] - 2018-05-11
 ### Added

--- a/omisego-sdk/src/main/java/co/omisego/omisego/OMGAPIClient.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/OMGAPIClient.kt
@@ -108,11 +108,11 @@ class OMGAPIClient(private val eWalletClient: EWalletClient) {
         eWalletAPI.createTransactionRequest(request)
 
     /**
-     * Asynchronously retrieve a transaction request from its id
+     * Asynchronously retrieve a transaction request from its formattedId
      * if *success* the [OMGCallback<TransactionRequest>] will be invoked with the [co.omisego.omisego.model.transaction.request.TransactionRequest] parameter,
      * if *fail* the [OMGCallback<TransactionRequest>] will be invoked with the [co.omisego.omisego.model.APIError] parameter.
      *
-     * @param request The id of the TransactionRequest to be retrieved
+     * @param request The formattedId of the TransactionRequest to be retrieved
      */
     fun retrieveTransactionRequest(request: TransactionRequestParams) =
         eWalletAPI.retrieveTransactionRequest(request)

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/consumption/TransactionConsumptionParams.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/consumption/TransactionConsumptionParams.kt
@@ -15,9 +15,9 @@ import java.math.BigDecimal
  */
 data class TransactionConsumptionParams internal constructor(
     /**
-     * The id of the transaction request to be consumed
+     * The formattedTransactionRequestId of the transaction request to be consumed
      */
-    private val transactionRequestId: String,
+    private val formattedTransactionRequestId: String,
 
     /**
      * The amount of token to transfer (down to subunit to unit)
@@ -39,7 +39,7 @@ data class TransactionConsumptionParams internal constructor(
     /**
      * The idempotency token to use for the consumption
      */
-    val idempotencyToken: String = "$transactionRequestId-${System.nanoTime()}",
+    val idempotencyToken: String = "$formattedTransactionRequestId-${System.nanoTime()}",
 
     /**
      *  An id that can uniquely identify a transaction. Typically an order id from a provider.
@@ -90,7 +90,7 @@ data class TransactionConsumptionParams internal constructor(
             }
 
             return TransactionConsumptionParams(
-                transactionRequest.id,
+                transactionRequest.formattedId,
                 if (transactionRequest.amount == amount) null else amount,
                 address,
                 tokenId,

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequest.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequest.kt
@@ -16,6 +16,7 @@ import co.omisego.omisego.model.transaction.consumption.TransactionConsumptionPa
 import kotlinx.android.parcel.Parcelize
 import co.omisego.omisego.operation.Listenable
 import co.omisego.omisego.websocket.SocketCustomEventListener
+import kotlinx.android.parcel.RawValue
 import java.math.BigDecimal
 import java.util.Date
 
@@ -68,6 +69,9 @@ enum class TransactionRequestStatus constructor(override val value: String) : OM
  * @param consumptionLifetime The amount of time in millisecond during which a consumption is valid
  * @param createdAt The creation date of the request
  * @param expiredAt The date when the request expired
+ * @param formattedId An id that can be encoded in a QR code and be used to retrieve the request later
+ * @param metadata Additional metadata for the transaction request
+ * @param encryptedMetadata Additional encrypted metadata for the transaction request
  */
 @Parcelize
 data class TransactionRequest(
@@ -86,7 +90,10 @@ data class TransactionRequest(
     val expirationReason: String?,
     val consumptionLifetime: Int?,
     val createdAt: Date?,
-    val expiredAt: Date?
+    val expiredAt: Date?,
+    val formattedId: String,
+    val metadata: @RawValue Map<String, Any>,
+    val encryptedMetadata: @RawValue Map<String, Any>
 ) : Parcelable, Listenable<SocketCustomEventListener.TransactionRequestListener>
 
 /**

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestParams.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestParams.kt
@@ -8,7 +8,7 @@ package co.omisego.omisego.model.transaction.request
  */
 data class TransactionRequestParams(
     /**
-     * The id of the TransactionRequest to be retrieved.
+     * The formattedId of the TransactionRequest to be retrieved.
      */
-    val id: String
+    val formattedId: String
 )

--- a/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/generator/QRGenerator.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/generator/QRGenerator.kt
@@ -39,9 +39,9 @@ class QRGenerator(
 }
 
 /**
- * Generates an QR bitmap containing the encoded transaction request id
+ * Generates an QR bitmap containing the encoded transaction request formattedId
  *
  * @param size the desired image size
  * @return An QR image if the transaction request was successfully encoded
  */
-fun TransactionRequest.generateQRCode(size: Int = QRGenerator.DEFAULT_SIZE): Bitmap = QRGenerator().generate(id, size)
+fun TransactionRequest.generateQRCode(size: Int = QRGenerator.DEFAULT_SIZE): Bitmap = QRGenerator().generate(formattedId, size)

--- a/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRScannerContract.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRScannerContract.kt
@@ -146,7 +146,7 @@ interface OMGQRScannerContract {
         /**
          * Verify if the given [txId] has already failed with code [ErrorCode.TRANSACTION_REQUEST_NOT_FOUND] yet
          *
-         * @param txId The transaction id which is created by EWallet backend
+         * @param txId The transaction formattedId which is created by EWallet backend
          * @return true if the given [txId] has already failed with code [ErrorCode.TRANSACTION_REQUEST_NOT_FOUND], otherwise false.
          */
         fun hasTransactionAlreadyFailed(txId: String): Boolean
@@ -163,9 +163,9 @@ interface OMGQRScannerContract {
             var callback: OMGCallback<TransactionRequest>?
 
             /**
-             * Make request to the EWallet API to verify if the QR code has a valid transaction id
+             * Make request to the EWallet API to verify if the QR code has a valid transaction formattedId
              *
-             * @param txId The transaction id which is created by EWallet backend
+             * @param txId The transaction formattedId which is created by EWallet backend
              * @param fail A lambda that will be invoked when the verification pass
              * @param success A lambda that will be invoked when the verification fail
              */

--- a/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRScannerLogic.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRScannerLogic.kt
@@ -165,10 +165,10 @@ internal class OMGQRScannerLogic(
             BinaryBitmap(HybridBinarizer(source.invert()))
         )
 
-        rawResult?.text?.let { txId ->
+        rawResult?.text?.let { formattedId ->
 
-            /* Return immediately if we've already processed this [txId] and it failed with [ErrorCode.TRANSACTION_REQUEST_NOT_FOUND] */
-            if (hasTransactionAlreadyFailed(txId)) {
+            /* Return immediately if we've already processed this [formattedId] and it failed with [ErrorCode.TRANSACTION_REQUEST_NOT_FOUND] */
+            if (hasTransactionAlreadyFailed(formattedId)) {
                 scanCallback?.scannerDidFailToDecode(omgQRScannerView, errorTxNotFound)
                 return@let
             }
@@ -177,11 +177,11 @@ internal class OMGQRScannerLogic(
             omgQRScannerView.isLoading = true
 
             /* Verify transactionId with the eWallet backend */
-            omgQRVerifier.requestTransaction(txId, { errorResponse ->
+            omgQRVerifier.requestTransaction(formattedId, { errorResponse ->
 
-                /* Cache txId if error with [ErrorCode.TRANSACTION_REQUEST_NOT_FOUND] code */
+                /* Cache formattedId if error with [ErrorCode.TRANSACTION_REQUEST_NOT_FOUND] code */
                 if (errorResponse.data.code == ErrorCode.TRANSACTION_REQUEST_NOT_FOUND) {
-                    qrPayloadCache.add(txId)
+                    qrPayloadCache.add(formattedId)
                 }
 
                 /* Delegate a fail callback */
@@ -209,12 +209,12 @@ internal class OMGQRScannerLogic(
     }
 
     /**
-     * Verify if the given [txId] has already failed with code [ErrorCode.TRANSACTION_REQUEST_NOT_FOUND] yet
+     * Verify if the given [formattedId] has already failed with code [ErrorCode.TRANSACTION_REQUEST_NOT_FOUND] yet
      *
-     * @param txId The transaction id which is created by EWallet backend
-     * @return true if the given [txId] has already failed with code [ErrorCode.TRANSACTION_REQUEST_NOT_FOUND], otherwise false.
+     * @param formattedId The transaction formattedId which is created by EWallet backend
+     * @return true if the given [formattedId] has already failed with code [ErrorCode.TRANSACTION_REQUEST_NOT_FOUND], otherwise false.
      */
-    override fun hasTransactionAlreadyFailed(txId: String) = qrPayloadCache.contains(txId)
+    override fun hasTransactionAlreadyFailed(formattedId: String) = qrPayloadCache.contains(formattedId)
 
     /**
      * Trying to decode first, if some exception arise, then return null.

--- a/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRVerifier.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRVerifier.kt
@@ -31,18 +31,18 @@ internal class OMGQRVerifier(
     override var callback: OMGCallback<TransactionRequest>? = null
 
     /**
-     * Make request to the EWallet API to verify if the QR code has a valid transaction id
+     * Make request to the EWallet API to verify if the QR code has a valid transaction formattedId
      *
-     * @param txId The transaction id which is created by EWallet backend
+     * @param formattedId The transaction formattedId which is created by EWallet backend
      * @param fail A lambda that will be invoked when the verification pass
      * @param success A lambda that will be invoked when the verification fail
      */
     override inline fun requestTransaction(
-        txId: String,
+        formattedId: String,
         crossinline fail: (response: OMGResponse<APIError>) -> Unit,
         crossinline success: (response: OMGResponse<TransactionRequest>) -> Unit
     ) {
-        callable = omgAPIClient.retrieveTransactionRequest(TransactionRequestParams(txId))
+        callable = omgAPIClient.retrieveTransactionRequest(TransactionRequestParams(formattedId))
         callback = callback ?: object : OMGCallback<TransactionRequest> {
             override fun success(response: OMGResponse<TransactionRequest>) = success(response)
             override fun fail(response: OMGResponse<APIError>) = fail(response)

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/consumption/TransactionConsumptionParamsTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/consumption/TransactionConsumptionParamsTest.kt
@@ -36,7 +36,7 @@ class TransactionConsumptionParamsTest {
     fun `TransactionConsumptionParams should be use amount null if transactionRequest amount equals the amount`() {
         val transactionRequest: TransactionRequest = mock()
 
-        whenever(transactionRequest.id).thenReturn("omg-test1234")
+        whenever(transactionRequest.formattedId).thenReturn("omg-test1234")
         whenever(transactionRequest.amount).thenReturn(1234.bd)
 
         val tx = TransactionConsumptionParams.create(transactionRequest, amount = 1234.bd)
@@ -47,7 +47,7 @@ class TransactionConsumptionParamsTest {
     fun `TransactionConsumptionParams should use amount as the sending amount if transactionRequest amount and the sending amount are not the same`() {
         val transactionRequest: TransactionRequest = mock()
 
-        whenever(transactionRequest.id).thenReturn("omg-test1234")
+        whenever(transactionRequest.formattedId).thenReturn("omg-test1234")
         whenever(transactionRequest.amount).thenReturn(1234.bd)
 
         val tx = TransactionConsumptionParams.create(transactionRequest, amount = 100.bd)
@@ -58,7 +58,7 @@ class TransactionConsumptionParamsTest {
     fun `TransactionConsumptionParams call function multiple times should produce unique idempotencyToken`() {
         val transactionRequest: TransactionRequest = mock()
 
-        whenever(transactionRequest.id).thenReturn("omg-test1234")
+        whenever(transactionRequest.formattedId).thenReturn("omg-test1234")
         whenever(transactionRequest.amount).thenReturn(1234.bd)
 
         val idempotencyTokenSet = mutableSetOf<String>()

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/consumption/TransactionConsumptionTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/consumption/TransactionConsumptionTest.kt
@@ -72,7 +72,10 @@ class TransactionConsumptionTest {
                 expiredAt = Date(),
                 createdAt = Date(),
                 expirationReason = "Hello",
-                status = TransactionRequestStatus.VALID
+                status = TransactionRequestStatus.VALID,
+                formattedId = "1234",
+                metadata = mapOf(),
+                encryptedMetadata = mapOf()
             ),
             SocketTopic("test"),
             Date(),

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/request/TransactionRequestTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/request/TransactionRequestTest.kt
@@ -43,7 +43,10 @@ class TransactionRequestTest {
             expiredAt = Date(),
             createdAt = Date(),
             expirationReason = "Hello",
-            status = TransactionRequestStatus.VALID
+            status = TransactionRequestStatus.VALID,
+            formattedId = "1234",
+            metadata = mapOf(),
+            encryptedMetadata = mapOf()
         )
     }
 


### PR DESCRIPTION
Issue/Task Number: `368-implement-formatted-id`

# Overview

This PR adds the changes from this PR.

# Changes

- Added `formattedId` to  `TransactionRequest`

- Changed `id` in `TransactionConsumptionParams` to `formattedId`

- Changed generate QR code mechanism to use `formattedTransactionId` instead of `transactionId`

# Implementation Details

- Use the refactoring tool to rename and add the `formattedId`

# Usage

`N/A`

# Impact

The `retrieveTransactionRequest` API need to pass `formattedId` instead of `id` 