### PR TITLE
Add max consumptions per user

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,8 +661,10 @@ transactionConsumption.startListeningEvents(socketClient, object: SocketCustomEv
 })
 ```
 
-> Note: You might want to listen for the event later after you got the `TransactionRequest` or `TransactionConsumption` object, but you might not want to pass the object around.
-In this case, it is possible to keep only the `SocketTopic` directly. Then you can alternatively listening for custom events by using `joinChannel` method of the `OMGSocketClient` instance.
+You might want to listen for the event later after you got the `TransactionRequest` or `TransactionConsumption` object, but you might not want to pass the object around.
+In this case, it is possible to keep only the `SocketTopic` directly. 
+
+Then you can alternatively listening for custom events by using `joinChannel` method of the `OMGSocketClient` instance.
 This implementation will provide the exactly same result as the implementation above ☝️. For example,
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ val request = TransactionRequestCreateParams(
     consumptionLifetime = 60000,
     expirationDate = null,
     allowAmountOverride = true,
+    maxConsumptionsPerUser = null,
     metadata = mapof<String, Any>(),
     encryptedMetadata = mapOf<String, Any>()
 )
@@ -308,12 +309,13 @@ Where:
     * `amount`: (optional) The amount of token to receive. This amount can be either inputted when generating or consuming a transaction request.
     * `address`: (optional) The address specifying where the transaction should be sent to. If not specified, the current user's primary wallet address will be used.
     * `correlationId`: (optional) An id that can uniquely identify a transaction. Typically an order id from a provider.
-    * `requireConfirmation`: A boolean indicating if the request needs a confirmation from the requester before being proceeded
-    * `maxConsumptions`: (optional) The maximum number of time that this request can be consumed
-    * `consumptionLifetime`: (optional) The amount of time in millisecond during which a consumption is valid
-    * `expirationDate`: (optional) The date when the request will expire and not be consumable anymore
+    * `requireConfirmation`: A boolean indicating if the request needs a confirmation from the requester before being proceeded.
+    * `maxConsumptions`: (optional) The maximum number of time that this request can be consumed. Default `null` (unlimited).
+    * `consumptionLifetime`: (optional) The amount of time in millisecond during which a consumption is valid. Default `null` (forever).
+    * `expirationDate`: (optional) The date when the request will expire and not be consumable anymore. Default `null` (never expired).
     * `allowAmountOverride`: (optional) Allow or not the consumer to override the amount specified in the request. This needs to be true if the amount is not specified
     > Note that if amount is nil and allowAmountOverride is false the init will fail and return null.
+    * `maxConsumptionsPerUser`: (optional) The maximum number of consumptions allowed per unique user. Default `null` (unlimited).
     * `metadata`: Additional metadata embedded with the request
     * `encryptedMetadata`: Additional encrypted metadata embedded with the request
 

--- a/omisego-sdk/src/main/java/co/omisego/omisego/constant/enums/ErrorCode.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/constant/enums/ErrorCode.kt
@@ -22,6 +22,11 @@ enum class ErrorCode constructor(private val code: String) {
     SERVER_INTERNAL_SERVER_ERROR("server:internal_server_error"),
     SERVER_UNKNOWN_ERROR("server:unknown_error"),
     TOKEN_NOT_FOUND("token:token_not_found"),
+    TRANSACTION_SAME_ADDRESS("transaction:same_address"),
+    TRANSACTION_INSUFFICIENT_FUNDS("transaction:insufficient_funds"),
+    TRANSACTION_REQUEST_EXPIRED("transaction_request:expired"),
+    TRANSACTION_REQUEST_MAX_CONSUMPTIONS_REACHED("transaction_request:max_consumptions_reached"),
+    TRANSACTION_REQUEST_MAX_CONSUMPTIONS_PER_USER_REACHED("transaction_request:max_consumptions_per_user_reached"),
     TRANSACTION_REQUEST_NOT_FOUND("transaction_request:transaction_request_not_found"),
     TRANSACTION_CONSUMPTION_NOT_OWNER("transaction_consumption:not_owner"),
     TRANSACTION_CONSUMPTION_INVALID_TOKEN("transaction_consumption:invalid_token"),
@@ -29,6 +34,7 @@ enum class ErrorCode constructor(private val code: String) {
     TRANSACTION_CONSUMPTION_UNFINALIZED("transaction_consumption:unfinalized"),
     WEBSOCKET_FORBIDDEN_CHANNEL("websocket:forbidden_channel"),
     WEBSOCKET_CHANNEL_NOT_FOUND("websocket:channel_not_found"),
+    WEB_SOCKET_CONNECT_ERROR("websocket:connect_error"),
 
     //Error code from OmiseGO user API
     USER_ACCESS_TOKEN_EXPIRED("user:access_token_expired"),

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequest.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequest.kt
@@ -60,13 +60,15 @@ enum class TransactionRequestStatus constructor(override val value: String) : OM
  * @param address The address from which to send or receive the tokens
  * @param user The user that initiated the request
  * @param socketTopic The topic which can be listened in order to receive events regarding this request
- * @param maxConsumption The maximum number of time that this request can be consumed
+ * @param maxConsumption The maximum number of time that this request can be consumed. Default null (unlimited).
  * @param status The status of the request (valid or expired)
  * @param allowAmountOverride Allow or not the consumer to override the amount specified in the request
+ * Note that if amount is nil and allowAmountOverride is false the init will fail and return null.
+ * @param maxConsumptionsPerUser The maximum number of consumptions allowed per unique user. Default null (unlimited).
  * @param requireConfirmation A boolean indicating if the request needs a confirmation from the requester before being proceeded
- * @param expirationDate The date when the request will expire and not be consumable anymore
+ * @param expirationDate The date when the request will expire and not be consumable anymore. Default null (never expired).
  * @param expirationReason The reason why the request expired
- * @param consumptionLifetime The amount of time in millisecond during which a consumption is valid
+ * @param consumptionLifetime The amount of time in millisecond during which a consumption is valid. Default null (forever).
  * @param createdAt The creation date of the request
  * @param expiredAt The date when the request expired
  * @param formattedId An id that can be encoded in a QR code and be used to retrieve the request later
@@ -85,6 +87,7 @@ data class TransactionRequest(
     val maxConsumption: Int?,
     val status: TransactionRequestStatus,
     val allowAmountOverride: Boolean,
+    val maxConsumptionsPerUser: Int?,
     val requireConfirmation: Boolean,
     val expirationDate: Date,
     val expirationReason: String?,

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/request/TransactionRequestCreateParams.kt
@@ -13,73 +13,39 @@ import java.util.Date
 /**
  * Represents a structure used to generate a transaction request
  *
+ * @param type The type of transaction to be generated (send of receive)
+ * @param tokenId The unique identifier of the token to use for the request
+ * In the case of a type "send", this will be the token taken from the requester
+ * In the case of a type "receive" this will be the token received by the requester
+ * @param amount The amount of token to use for the transaction (down to subunit to unit)
+ * This amount can be either inputted when generating or consuming a transaction request.
+ * @param address The address specifying where the transaction should be sent to.
+ * If not specified, the current user's primary wallet address will be used.
+ * @param requireConfirmation A boolean indicating if the request needs a confirmation from the requester before being proceeded. Default true.
+ * @param allowAmountOverride Allow or not the consumer to override the amount specified in the request
+ * This needs to be true if the amount is not specified. Default true.
+ * @param correlationId An id that can uniquely identify a transaction. Typically an order id from a provider.
+ * @param maxConsumptions The maximum number of time that this request can be consumed. Default null (unlimited).
+ * @param maxConsumptionsPerUser The maximum number of consumptions allowed per unique user. Default null (unlimited).
+ * @param consumptionLifetime The amount of time in millisecond during which a consumption is valid. Default null (forever).
+ * @param expirationDate The date when the request will expire and not be consumable anymore. Default null (forever).
+ * @param metadata Additional metadata embedded with the request
+ * @param encryptedMetadata Additional encrypted metadata embedded with the request
  */
 data class TransactionRequestCreateParams(
-
-    /**
-     * The type of transaction to be generated (send of receive)
-     */
     val type: TransactionRequestType = TransactionRequestType.RECEIVE,
-
-    /**
-     * The unique identifier of the token to use for the request
-     * In the case of a type "send", this will be the token taken from the requester
-     * In the case of a type "receive" this will be the token received by the requester
-     */
     val tokenId: String,
-
-    /**
-     * The amount of token to use for the transaction (down to subunit to unit)
-     * This amount can be either inputted when generating or consuming a transaction request.
-     */
     val amount: BigDecimal? = null,
-
-    /**
-     * The address specifying where the transaction should be sent to.
-     * If not specified, the current user's primary wallet address will be used.
-     */
     val address: String? = null,
-
-    /**
-     * A boolean indicating if the request needs a confirmation from the requester before being proceeded
-     */
     val requireConfirmation: Boolean = true,
-
-    /**
-     * Allow or not the consumer to override the amount specified in the request
-     * This needs to be true if the amount is not specified
-     */
     val allowAmountOverride: Boolean = true,
-
-    /**
-     * Additional metadata embedded with the request
-     */
-    val metadata: Map<String, Any> = mapOf(),
-
-    /**
-     * Additional encrypted metadata embedded with the request
-     */
-    val encryptedMetadata: Map<String, Any> = mapOf(),
-
-    /**
-     * An id that can uniquely identify a transaction. Typically an order id from a provider.
-     */
     val correlationId: String? = null,
-
-    /**
-     * The maximum number of time that this request can be consumed
-     */
     val maxConsumptions: Int? = null,
-
-    /**
-     * The amount of time in millisecond during which a consumption is valid
-     */
+    val maxConsumptionsPerUser: Int? = null,
     val consumptionLifetime: Int? = null,
-
-    /**
-     * The date when the request will expire and not be consumable anymore
-     */
-    val expirationDate: Date? = null
+    val expirationDate: Date? = null,
+    val metadata: Map<String, Any> = mapOf(),
+    val encryptedMetadata: Map<String, Any> = mapOf()
 ) {
 
     init {

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/constant/ErrorCodeTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/constant/ErrorCodeTest.kt
@@ -48,6 +48,11 @@ class ErrorCodeTest {
                 "token:token_not_found" -> ErrorCode.TOKEN_NOT_FOUND
                 "sdk:socket_error" -> ErrorCode.SDK_SOCKET_ERROR
                 "token:token_not_found" -> ErrorCode.TOKEN_NOT_FOUND
+                "transaction:same_address" -> ErrorCode.TRANSACTION_SAME_ADDRESS
+                "transaction:insufficient_funds" -> ErrorCode.TRANSACTION_INSUFFICIENT_FUNDS
+                "transaction_request:expired" -> ErrorCode.TRANSACTION_REQUEST_EXPIRED
+                "transaction_request:max_consumptions_reached" -> ErrorCode.TRANSACTION_REQUEST_MAX_CONSUMPTIONS_REACHED
+                "transaction_request:max_consumptions_per_user_reached" -> ErrorCode.TRANSACTION_REQUEST_MAX_CONSUMPTIONS_PER_USER_REACHED
                 "transaction_request:transaction_request_not_found" -> ErrorCode.TRANSACTION_REQUEST_NOT_FOUND
                 "transaction_consumption:not_owner" -> ErrorCode.TRANSACTION_CONSUMPTION_NOT_OWNER
                 "transaction_consumption:invalid_token" -> ErrorCode.TRANSACTION_CONSUMPTION_INVALID_TOKEN
@@ -55,6 +60,7 @@ class ErrorCodeTest {
                 "transaction_consumption:unfinalized" -> ErrorCode.TRANSACTION_CONSUMPTION_UNFINALIZED
                 "websocket:forbidden_channel" -> ErrorCode.WEBSOCKET_FORBIDDEN_CHANNEL
                 "websocket:channel_not_found" -> ErrorCode.WEBSOCKET_CHANNEL_NOT_FOUND
+                "websocket:connect_error" -> ErrorCode.WEB_SOCKET_CONNECT_ERROR
                 else -> ErrorCode.SDK_UNEXPECTED_ERROR
             }
             actual shouldEqual expected

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/consumption/TransactionConsumptionTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/consumption/TransactionConsumptionTest.kt
@@ -66,6 +66,7 @@ class TransactionConsumptionTest {
                 socketTopic = SocketTopic("1234"),
                 maxConsumption = 1234,
                 allowAmountOverride = false,
+                maxConsumptionsPerUser = 5,
                 address = "1234",
                 user = null,
                 consumptionLifetime = 10,

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/request/TransactionRequestTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/request/TransactionRequestTest.kt
@@ -37,6 +37,7 @@ class TransactionRequestTest {
             socketTopic = SocketTopic("1234"),
             maxConsumption = 1234,
             allowAmountOverride = false,
+            maxConsumptionsPerUser = null,
             address = "1234",
             user = null,
             consumptionLifetime = 10,

--- a/omisego-sdk/src/test/resources/transaction_request.json
+++ b/omisego-sdk/src/test/resources/transaction_request.json
@@ -23,6 +23,7 @@
     "correlation_id": null,
     "amount": 100,
     "address": "dec1342d-d76b-4f78-bfe6-3f9aa984a822",
+    "maxConsumptionsPerUser": 5,
     "account_id": null
   }
 }


### PR DESCRIPTION
Issue/Task Number: `327-add-max-consumptions-per-user`

# Overview

Add `maxConsumptionsPerUser` to `TransactionRequest` and `TransactionRequestCreateParams`. The default value is null (unlimited).

# Changes

- Add `maxConsumptionsPerUser` to `TransactionRequest`
- Add `maxConsumptionsPerUser` to `TransactionRequestCreateParams`
- Add more error codes

# Implementation Details

Add the attribute and improve documentation.

# Usage

Assign an `integer` to specify the total consumptions per user.

# Impact

`N/A`