### PR TITLE
Fix proguard config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and `OmiseGO` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
-## [0.9.4] - 2018-05-xx
+## [0.9.42] - 2018-06-15
+### Fixed
+- [SDK package version `0.9.4` doesn't contain any class](https://github.com/omisego/android-sdk/issues/36)
+
+## [0.9.4] - 2018-06-14
 ### Added
 - [Websocket](https://github.com/omisego/android-sdk#websocket)
 - [Transfer](https://github.com/omisego/android-sdk#send-tokens-to-an-address)
@@ -44,7 +48,8 @@ and `OmiseGO` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Logout the current user
 - [OMGKeyManager - encryption and decryption helpers](https://github.com/omisego/android-sdk/pull/11)
 
-[Unreleased]: https://github.com/omisego/android-sdk/compare/v0.9.4...HEAD
-[0.9.4]: https://github.com/omisego/android-sdk/compare/v0.9.4...v0.9.3
+[Unreleased]: https://github.com/omisego/android-sdk/compare/v0.9.42...HEAD
+[0.9.42]: https://github.com/omisego/android-sdk/compare/v0.9.4...0.9.42
+[0.9.4]: https://github.com/omisego/android-sdk/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/omisego/android-sdk/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/omisego/android-sdk/compare/v0.9.1...v0.9.2

--- a/build.gradle
+++ b/build.gradle
@@ -31,5 +31,5 @@ task clean(type: Delete) {
 }
 
 ext {
-    versionName = "0.9.4"
+    versionName = "0.9.42"
 }

--- a/omisego-sdk/build.gradle
+++ b/omisego-sdk/build.gradle
@@ -8,6 +8,7 @@ apply plugin: 'com.adarshr.test-logger'
 apply from: 'dokka.gradle'
 
 android {
+    buildToolsVersion '27.0.3'
     compileSdkVersion 27
     defaultConfig {
         minSdkVersion 19

--- a/omisego-sdk/build.gradle
+++ b/omisego-sdk/build.gradle
@@ -17,13 +17,6 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-proguard-rules.pro'
     }
-    buildToolsVersion '27.0.3'
-    buildTypes {
-        release {
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
     sourceSets {
         test.java.srcDirs += 'src/test/kotlin'
         androidTest.java.srcDirs += 'src/androidTest/kotlin'

--- a/omisego-sdk/consumer-proguard-rules.pro
+++ b/omisego-sdk/consumer-proguard-rules.pro
@@ -1,6 +1,4 @@
-# OMG
--keep class co.omisego.omisego.model.** { *; }
--keep class co.omisego.omisego.websocket.enum.** { *; }
+-keep public class co.omisego.omisego.** { *; }
 
 # Save the obfuscation mapping to a file, so we can de-obfuscate any stack
 # traces later on. Keep a fixed source file attribute and all line number

--- a/omisego-sdk/consumer-proguard-rules.pro
+++ b/omisego-sdk/consumer-proguard-rules.pro
@@ -1,4 +1,6 @@
--keep public class co.omisego.omisego.** { *; }
+# OMG
+-keep class co.omisego.omisego.model.** { *; }
+-keep class co.omisego.omisego.websocket.enum.** { *; }
 
 # Save the obfuscation mapping to a file, so we can de-obfuscate any stack
 # traces later on. Keep a fixed source file attribute and all line number


### PR DESCRIPTION
Issue/Task Number: `405-fix-proguard`

# Overview

From issue https://github.com/omisego/android-sdk/issues/36

Currently, we set `minifyEnabled` is `true` lead to no classes available when publishing the package to Bintray. This PR will set it to false by removing the `buildType` block to use its default setup.

# Changes

1. Set `minifyEnabled` to false.

2. Increase SDK version.

3. Fewer strict `consumer-proguard-rules`.

# Implementation Details

1. Remove config for release build in `build.gradle`

2. Update version to `0.9.42` for preparing release new version. (`0.9.4` is broken)

# Usage

`N/A`

# Impact

The issue From issue https://github.com/omisego/android-sdk/issues/36 will be fixed.