### PR TITLE
Remove Idempotency-Token from header

### DIFF
--- a/omisego-sdk/src/main/java/co/omisego/omisego/network/ewallet/EWalletAPI.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/network/ewallet/EWalletAPI.kt
@@ -34,7 +34,6 @@ import co.omisego.omisego.model.transaction.request.TransactionRequestCreatePara
 import co.omisego.omisego.model.transaction.request.TransactionRequestParams
 import co.omisego.omisego.model.transaction.send.TransactionSendParam
 import retrofit2.http.Body
-import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface EWalletAPI {
@@ -61,8 +60,7 @@ interface EWalletAPI {
 
     @POST(CONSUME_TRANSACTION_REQUEST)
     fun consumeTransactionRequest(
-        @Body request: TransactionConsumptionParams,
-        @Header("Idempotency-Token") idempotencyToken: String = request.idempotencyToken
+        @Body request: TransactionConsumptionParams
     ): OMGCall<TransactionConsumption>
 
     @POST(APPROVE_TRANSACTION)


### PR DESCRIPTION
Issue/Task Number: `412-remove-idempotency-token-from-header`

# Overview

This PR removes the idempotency token from header (following [this PR](https://github.com/omisego/ewallet/pull/246))

# Changes

Remove `Idempotency-Token` from header

# Implementation Details

Remove `Idempotency-Token` from the header in `EWalletAPI` interface

# Usage

`N/A`

# Impact

`N/A`