### PR TITLE
Rename and add missing metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and `OmiseGO` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [Unreleased]
 
 ## [0.9.42] - 2018-06-15
+### Added
+- Added `metadata` and `encryptedMetadata` params to `Token` class. 
+
 ### Fixed
 - [SDK package version `0.9.4` doesn't contain any class](https://github.com/omisego/android-sdk/issues/36)
+- [Cannot get metadata of the user](https://github.com/omisego/android-sdk/issues/40)
 
 ### Changed
 - Renamed endpoint `listTransactions` to `getTransactions`

--- a/README.md
+++ b/README.md
@@ -50,10 +50,9 @@ To use the OmiseGO SDK in your android project, simply add the following line in
  
 ```groovy
 dependencies {
-    implementation 'co.omisego:omisego-sdk:0.9.3'
+    implementation 'co.omisego:omisego-sdk:<latest-sdk-version>'
 }
 ```
-
 ## Usage
 
 ### Initialization

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/Token.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/Token.kt
@@ -9,6 +9,7 @@ package co.omisego.omisego.model
 
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
+import kotlinx.android.parcel.RawValue
 import java.math.BigDecimal
 
 /**
@@ -20,9 +21,18 @@ import java.math.BigDecimal
  * @param subunitToUnit The multiplier representing the value of 1 token,
  *  i.e: If I want to give or receive 13 tokens and the [subunitToUnit] is 1000,
  *  then the amount will be 13*1000 = 13000
+ * @param metadata Any additional metadata that need to be stored as a [HashMap].
+ * @param encryptedMetadata Any additional encrypted metadata that need to be stored as a dictionary.
  */
 @Parcelize
-data class Token(val id: String, val symbol: String, val name: String, val subunitToUnit: BigDecimal) : Parcelable {
+data class Token(
+    val id: String,
+    val symbol: String,
+    val name: String,
+    val subunitToUnit: BigDecimal,
+    val metadata: @RawValue Map<String, Any>,
+    val encryptedMetadata: @RawValue Map<String, Any>
+) : Parcelable {
 
     /**
      * Compares the current [Token] with the specified [Token] for verifying both [Token] are compatible.

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/User.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/User.kt
@@ -1,11 +1,11 @@
 package co.omisego.omisego.model
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
-import kotlinx.android.parcel.RawValue
 import co.omisego.omisego.model.socket.SocketTopic
 import co.omisego.omisego.operation.Listenable
 import co.omisego.omisego.websocket.SocketCustomEventListener
+import kotlinx.android.parcel.Parcelize
+import kotlinx.android.parcel.RawValue
 import java.util.Date
 
 /*
@@ -21,7 +21,7 @@ import java.util.Date
  * @param id The unique identifier on the wallet server side.
  * @param providerUserId The user identifier on the provider server side.
  * @param username The user's username, it can be an email or any name describing this user.
- * @param metaData Any additional metadata that need to be stored as a [HashMap].
+ * @param metadata Any additional metadata that need to be stored as a [HashMap].
  * @param encryptedMetadata Any additional encrypted metadata that need to be stored as a dictionary.
  * @param socketTopic The socket URL from where to receive from.
  * @param createdAt The creation date of the user.
@@ -33,7 +33,7 @@ data class User(
     val id: String,
     val providerUserId: String,
     val username: String,
-    val metaData: @RawValue Map<String, Any>,
+    val metadata: @RawValue Map<String, Any>,
     val encryptedMetadata: @RawValue Map<String, Any>,
     override val socketTopic: SocketTopic<SocketCustomEventListener>,
     val createdAt: Date,

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/BalanceTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/BalanceTest.kt
@@ -29,7 +29,7 @@ class BalanceTest {
 
     @Before
     fun setup() {
-        token = Token("omg:1234", "OMG", "OmiseGO", subUnitToUnit)
+        token = Token("omg:1234", "OMG", "OmiseGO", subUnitToUnit, mapOf(), mapOf())
     }
 
     @Test
@@ -80,8 +80,8 @@ class BalanceTest {
 
     @Test
     fun `test balance + another balance should be correct`() {
-        val balance1 = Balance(1_999_000_000_000.0.bd, Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd))
-        val balance2 = Balance(9_999_000_000_000.0.bd, Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd))
+        val balance1 = Balance(1_999_000_000_000.0.bd, Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd, mapOf(), mapOf()))
+        val balance2 = Balance(9_999_000_000_000.0.bd, Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd, mapOf(), mapOf()))
 
         val result = balance1 + balance2
         result.amount shouldEqual 11_998_000_000_000.0.bd
@@ -89,8 +89,8 @@ class BalanceTest {
 
     @Test
     fun `test balance - another balance should be correct`() {
-        val balance1 = Balance(11_998_000_000_000.0.bd, Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd))
-        val balance2 = Balance(9_999_000_000_000.0.bd, Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd))
+        val balance1 = Balance(11_998_000_000_000.0.bd, Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd, mapOf(), mapOf()))
+        val balance2 = Balance(9_999_000_000_000.0.bd, Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd, mapOf(), mapOf()))
 
         val result = balance1 - balance2
         result.amount shouldEqual 1_999_000_000_000.0.bd
@@ -101,15 +101,15 @@ class BalanceTest {
 
     @Test(expected = UnsupportedOperationException::class)
     fun `test balance + incompatible balance should throw UnSupportOperationException`() {
-        val balance1 = Balance(1_999_000_000_000.0.bd, Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd))
-        val balance2 = Balance(9_999_000_000_000.0.bd, Token("ETH:8bcda572-9411-43c8-baae-cd56eb0155f3", "ETH", "Etherium", 10000.0.bd))
+        val balance1 = Balance(1_999_000_000_000.0.bd, Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd, mapOf(), mapOf()))
+        val balance2 = Balance(9_999_000_000_000.0.bd, Token("ETH:8bcda572-9411-43c8-baae-cd56eb0155f3", "ETH", "Etherium", 10000.0.bd, mapOf(), mapOf()))
 
         balance1 + balance2
     }
 
     @Test
     fun `Balance should be parcelized correctly`() {
-        val balance1 = Balance(1_999_000_000_000.0.bd, Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd))
+        val balance1 = Balance(1_999_000_000_000.0.bd, Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd, mapOf(), mapOf()))
         balance1.validateParcel().apply {
             this shouldEqual balance1
             this shouldNotBe balance1

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/SettingTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/SettingTest.kt
@@ -25,8 +25,8 @@ class SettingTest {
     @Before
     fun setup() {
         setting = Setting(listOf(
-            Token("1", "OMG", "OmiseGO", 10000.bd),
-            Token("2", "ETH", "Ether", 10000000000000.bd)
+            Token("1", "OMG", "OmiseGO", 10000.bd, mapOf(), mapOf()),
+            Token("2", "ETH", "Ether", 10000000000000.bd, mapOf(), mapOf())
         ))
     }
 

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/TokenTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/TokenTest.kt
@@ -13,10 +13,10 @@ import org.amshove.kluent.shouldEqualTo
 import org.junit.Test
 
 class TokenTest {
-    val token1 = Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd)
-    val token2 = Token("ETH:8bcda572-9411-43c8-baae-cd56eb0155f3", "ETH", "Ethereum", 10000.0.bd)
-    val token3 = Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10.0.bd)
-    val token4 = Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd)
+    val token1 = Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd, mapOf(), mapOf())
+    val token2 = Token("ETH:8bcda572-9411-43c8-baae-cd56eb0155f3", "ETH", "Ethereum", 10000.0.bd, mapOf(), mapOf())
+    val token3 = Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10.0.bd, mapOf(), mapOf())
+    val token4 = Token("OMG:8bcda572-9411-43c8-baae-cd56eb0155f3", "OMG", "OmiseGO", 10000.0.bd, mapOf(), mapOf())
 
     @Test
     fun `token1 should be not compatible with token2`() {

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/WalletTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/WalletTest.kt
@@ -27,8 +27,8 @@ class WalletTest {
         address = Wallet(
             "1234-1234-1234",
             listOf(
-                Balance(100.bd, Token("1234", "OMG", "OmiseGO", 100.bd)),
-                Balance(100000000.bd, Token("1234-1234-1235-12345", "ETH", "Ether", 100000000.bd))
+                Balance(100.bd, Token("1234", "OMG", "OmiseGO", 100.bd, mapOf(), mapOf())),
+                Balance(100000000.bd, Token("1234-1234-1235-12345", "ETH", "Ether", 100000000.bd, mapOf(), mapOf()))
             ),
             "",
             "",

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/consumption/TransactionConsumptionTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/consumption/TransactionConsumptionTest.kt
@@ -34,7 +34,7 @@ import java.util.Date
 @Config(sdk = [23])
 class TransactionConsumptionTest {
     private val mOMGAPIClient: OMGAPIClient by lazy { mock<OMGAPIClient>() }
-    val token = Token("1234", "OMG", "OmiseGO", 10000.bd)
+    val token = Token("1234", "OMG", "OmiseGO", 10000.bd, mapOf(), mapOf())
     private val mTransactionConsumption: TransactionConsumption by lazy {
         TransactionConsumption(
             "OMG-1234",

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/request/TransactionRequestTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/request/TransactionRequestTest.kt
@@ -30,7 +30,7 @@ class TransactionRequestTest {
         transactionRequest = TransactionRequest(
             "1234",
             TransactionRequestType.RECEIVE,
-            Token("1234", "OMG", "OmiseGO", 1000.bd),
+            Token("1234", "OMG", "OmiseGO", 1000.bd, mapOf(), mapOf()),
             100.bd,
             expirationDate = Date(),
             requireConfirmation = false,


### PR DESCRIPTION
Issue/Task Number: `417-rename-and-add-missing-metadata`

# Overview

This PR will fix the issue https://github.com/omisego/android-sdk/issues/40 and add missing `metadata` and `encryptedMetadata` to model class.

# Changes

- Added `metadata` and `encryptedMetadata` to `Token` class.
- Rename variable `metaData` to `metadata` in the `User` class.

# Implementation Details

`N/A`

# Usage

`N/A`

# Impact

The SDK will parse `metadata` and `encryptedMetadata` correctly.