### PR TITLE
Rename error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and `OmiseGO` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.9.5] - 2018-06-22
 ### Changed
 - [Changed some non-nullable variable to nullable variables](https://github.com/omisego/android-sdk/pull/43)
+- Renamed an error code from `ErrorCode.USER_ACCESS_TOKEN_NOT_FOUND` to `ErrorCode.USER_AUTH_TOKEN_NOT_FOUND`
 
 ## [0.9.42] - 2018-06-15
 ### Added

--- a/omisego-sdk/src/main/java/co/omisego/omisego/constant/enums/ErrorCode.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/constant/enums/ErrorCode.kt
@@ -38,7 +38,7 @@ enum class ErrorCode constructor(private val code: String) {
 
     //Error code from OmiseGO user API
     USER_ACCESS_TOKEN_EXPIRED("user:access_token_expired"),
-    USER_ACCESS_TOKEN_NOT_FOUND("user:access_token_not_found"),
+    USER_AUTH_TOKEN_NOT_FOUND("user:auth_token_not_found"),
     USER_FROM_ADDRESS_NOT_FOUND("user:from_address_not_found"),
     USER_FROM_ADDRESS_MISMATCH("user:from_address_mismatch"),
 

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/constant/ErrorCodeTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/constant/ErrorCodeTest.kt
@@ -38,7 +38,7 @@ class ErrorCodeTest {
                 "client:invalid_auth_scheme" -> ErrorCode.CLIENT_INVALID_AUTH_SCHEME
                 "server:internal_server_error" -> ErrorCode.SERVER_INTERNAL_SERVER_ERROR
                 "server:unknown_error" -> ErrorCode.SERVER_UNKNOWN_ERROR
-                "user:access_token_not_found" -> ErrorCode.USER_ACCESS_TOKEN_NOT_FOUND
+                "user:auth_token_not_found" -> ErrorCode.USER_AUTH_TOKEN_NOT_FOUND
                 "user:access_token_expired" -> ErrorCode.USER_ACCESS_TOKEN_EXPIRED
                 "user:from_address_not_found" -> ErrorCode.USER_FROM_ADDRESS_NOT_FOUND
                 "user:from_address_mismatch" -> ErrorCode.USER_FROM_ADDRESS_MISMATCH


### PR DESCRIPTION
Issue/Task Number: `442-rename-error-code`

# Overview

Renamed an error code from `ErrorCode.USER_ACCESS_TOKEN_NOT_FOUND` to `ErrorCode.USER_AUTH_TOKEN_NOT_FOUND`