### PR TITLE
Fix param name

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -42,7 +42,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -42,7 +42,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and `OmiseGO` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.9.51] - 2018-06-22
+### Changed
+- Renamed `sortDirection` to `sortDir`
+
 ## [0.9.5] - 2018-06-22
 ### Changed
 - [Changed some non-nullable variable to nullable variables](https://github.com/omisego/android-sdk/pull/43)

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ val request = ListTransactionParams.create(
     page = 1,
     perPage = 10,
     sortBy = Paginable.Transaction.SortableFields.CREATE_AT,
-    sortDirection = SortDirection.ASCENDING,
+    sortDir = SortDirection.ASCENDING,
     searchTerm = "confirmed", // or searchTerms = mapOf(STATUS to "completed")
     address = null
 )
@@ -183,7 +183,7 @@ Where
     
     > `import co.omisego.omisego.model.pagination.Paginable.Transaction.SortableFields.*`
     
-* `sortDirection` is the sorting direction. The available values are:
+* `sortDir` is the sorting direction. The available values are:
     
     `ASCENDING`, `DESCENDING`
     

--- a/build.gradle
+++ b/build.gradle
@@ -31,5 +31,5 @@ task clean(type: Delete) {
 }
 
 ext {
-    versionName = "0.9.5"
+    versionName = "0.9.51"
 }

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/list/TransactionListParams.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/list/TransactionListParams.kt
@@ -43,7 +43,7 @@ data class TransactionListParams internal constructor(
      * - [SortDirection.ASCENDING]
      * - [SortDirection.DESCENDING]
      */
-    val sortDirection: SortDirection = SortDirection.DESCENDING,
+    val sortDir: SortDirection = SortDirection.DESCENDING,
 
     /**
      * A term to search for in all of the searchable fields.
@@ -70,14 +70,14 @@ data class TransactionListParams internal constructor(
             page: Int = 1,
             perPage: Int = 10,
             sortBy: Paginable.Transaction.SortableFields = Paginable.Transaction.SortableFields.CREATED_AT,
-            sortDirection: SortDirection = SortDirection.DESCENDING,
+            sortDir: SortDirection = SortDirection.DESCENDING,
             searchTerm: String? = null,
             address: String? = null
         ) = TransactionListParams(
             page = page,
             perPage = perPage,
             sortBy = sortBy,
-            sortDirection = sortDirection,
+            sortDir = sortDir,
             searchTerm = searchTerm,
             address = address
         )
@@ -86,14 +86,14 @@ data class TransactionListParams internal constructor(
             page: Int = 1,
             perPage: Int = 10,
             sortBy: Paginable.Transaction.SortableFields = Paginable.Transaction.SortableFields.CREATED_AT,
-            sortDirection: SortDirection = SortDirection.DESCENDING,
+            sortDir: SortDirection = SortDirection.DESCENDING,
             searchTerms: Map<Paginable.Transaction.SearchableFields, Any>? = null,
             address: String? = null
         ) = TransactionListParams(
             page = page,
             perPage = perPage,
             sortBy = sortBy,
-            sortDirection = sortDirection,
+            sortDir = sortDir,
             searchTerms = searchTerms,
             address = address
         )

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/TransactionListParamsTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/TransactionListParamsTest.kt
@@ -36,7 +36,7 @@ class TransactionListParamsTest {
         )
 
         val expected = """
-            {"page":1,"per_page":10,"sort_by":"from","sort_direction":"asc","search_term":"test","search_terms":{"status":"completed","id":"1234"},"address":"address:1234"}
+            {"page":1,"per_page":10,"sort_by":"from","sort_dir":"asc","search_term":"test","search_terms":{"status":"completed","id":"1234"},"address":"address:1234"}
         """.trimIndent()
 
         val actual = gson.toJson(transactionListParams)


### PR DESCRIPTION
Issue/Task Number: `444-fix-param-name`

# Overview

Changed wrong param name `sortDirection` to `sortDir`.