### PR TITLE
Fix bug encryption on Android version below 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and `OmiseGO` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.9.6] - 2018-06-27
+### Fixed
+- [OMGKeyManager throws an exception during the initialization steps on Android 5.1.1](https://github.com/omisego/android-sdk/issues/49)
+
 ## [0.9.52] - 2018-06-26
 ### Changed
 - Improved `OMGCameraPreview` performance

--- a/build.gradle
+++ b/build.gradle
@@ -31,5 +31,5 @@ task clean(type: Delete) {
 }
 
 ext {
-    versionName = "0.9.52"
+    versionName = "0.9.6"
 }

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerPreMarshmallow.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/KeyManagerPreMarshmallow.kt
@@ -26,8 +26,12 @@ internal class KeyManagerPreMarshmallow(
     private val keyManagerPreference: KeyManagerPreference
 ) : KeyManager(keyHolder) {
 
-    override val encryptCipher: Cipher by lazy { Cipher.getInstance(AES_MODE) }
-    override val decryptCipher: Cipher by lazy { Cipher.getInstance(AES_MODE, "BC") }
+    override val encryptCipher: Cipher by lazy {
+        Cipher.getInstance(AES_MODE).also { initCipher(it, Cipher.ENCRYPT_MODE) }
+    }
+    override val decryptCipher: Cipher by lazy {
+        Cipher.getInstance(AES_MODE, "BC").also { initCipher(it, Cipher.DECRYPT_MODE) }
+    }
 
     override val b64Mode: Int
         get() = Base64.NO_WRAP

--- a/omisego-sdk/src/main/java/co/omisego/omisego/security/OMGKeyManager.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/security/OMGKeyManager.kt
@@ -50,6 +50,7 @@ class OMGKeyManager private constructor(private var keyManager: KeyManager) {
      */
     class Builder(init: Builder.() -> Unit) {
         private lateinit var keyManager: KeyManager
+        private lateinit var keyManagerPreference: KeyManagerPreference
 
         var keyAlias: String = ""
         /**
@@ -81,16 +82,18 @@ class OMGKeyManager private constructor(private var keyManager: KeyManager) {
             val keyHolder = KeyHolder(keyStore, keyAlias)
 
             keyManager =
-                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-                        val rsaCipher = RSACipher(keyHolder)
-                        val keyManagerPreference = KeyManagerPreference(context, rsaCipher)
-                        keyManagerPreference.saveAESKeyIfAbsent()
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                    val rsaCipher = RSACipher(keyHolder)
+                    keyManagerPreference = KeyManagerPreference(context, rsaCipher)
+                    KeyManagerPreMarshmallow(keyHolder, keyManagerPreference)
+                } else {
+                    KeyManagerMarshmallow(keyHolder, iv)
+                }
 
-                        KeyManagerPreMarshmallow(keyHolder, keyManagerPreference)
-                    } else {
-                        KeyManagerMarshmallow(keyHolder, iv)
-                    }
             keyManager.create(context)
+
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M)
+                keyManagerPreference.saveAESKeyIfAbsent()
 
             return OMGKeyManager(keyManager)
         }


### PR DESCRIPTION
Issue/Task Number: `457-fix-bug-encryption-below-marshmallow`

# Overview

Currently, we have the issue on the Android version below Marshmallow to use the `OMGKeyManager`.

Here's the problem I've found:

1. `NullPointerException` is thrown when the `keyManagerPreference.saveAESKeyIfAbsent()` is called

2. When I've fixed ☝️, I found the encryption also not works because of the `cipher` throws `IllegalStateException`

# Changes

1. Swap the execution order in `OMGKeyManager`.

2. Call `initCipher` before using it

# Implementation Details

1. The cause of problem 1 is the `keyManagerPreference.saveAESKeyIfAbsent()` was called before the `KeyPairGeneratorSpec` was built. So it doesn't find the`KeyPair` to use for `encryption` or `decryption`

So the `keyManagerPreference.saveAESKeyIfAbsent()` should be executed after the `keyManager.create(context)`

2. The cause of problem 2 is we didn't execute `initCipher` before using the `cipher` for encryption and decryption.

# Usage

Same.

# Impact

`N/A`