### PR TITLE
Fix QR scanner doesn't cache invalid transaction id correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and `OmiseGO` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.9.6] - 2018-06-27
 ### Fixed
 - [OMGKeyManager throws an exception during the initialization steps on Android 5.1.1](https://github.com/omisego/android-sdk/issues/49)
+- [Fix bug QR scanner doesn't cache invalid transaction id correctly](https://github.com/omisego/android-sdk/issues/51)
 
 ## [0.9.52] - 2018-06-26
 ### Changed
@@ -74,11 +75,12 @@ and `OmiseGO` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Logout the current user
 - [OMGKeyManager - encryption and decryption helpers](https://github.com/omisego/android-sdk/pull/11)
 
-[Unreleased]: https://github.com/omisego/android-sdk/compare/v0.9.52...HEAD
-[0.9.52]: https://github.com/omisego/android-sdk/compare/v0.9.51...0.9.52
-[0.9.51]: https://github.com/omisego/android-sdk/compare/v0.9.5...0.9.51
-[0.9.5]: https://github.com/omisego/android-sdk/compare/v0.9.42...0.9.5
-[0.9.42]: https://github.com/omisego/android-sdk/compare/v0.9.4...0.9.42
+[Unreleased]: https://github.com/omisego/android-sdk/compare/v0.9.6...HEAD
+[0.9.6]: https://github.com/omisego/android-sdk/compare/v0.9.52...v0.9.6
+[0.9.52]: https://github.com/omisego/android-sdk/compare/v0.9.51...v0.9.52
+[0.9.51]: https://github.com/omisego/android-sdk/compare/v0.9.5...v0.9.51
+[0.9.5]: https://github.com/omisego/android-sdk/compare/v0.9.42...v0.9.5
+[0.9.42]: https://github.com/omisego/android-sdk/compare/v0.9.4...v0.9.42
 [0.9.4]: https://github.com/omisego/android-sdk/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/omisego/android-sdk/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/omisego/android-sdk/compare/v0.9.1...v0.9.2

--- a/omisego-sdk/src/main/java/co/omisego/omisego/custom/camera/ui/CameraPreviewContract.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/custom/camera/ui/CameraPreviewContract.kt
@@ -27,10 +27,10 @@ interface CameraPreviewContract {
         val previewLayoutParams: ViewGroup.LayoutParams
         val windowManager: WindowManager
 
-        fun stopCameraPreview()
         fun setCamera(cameraWrapper: CameraWrapper?, previewCallback: Camera.PreviewCallback)
         fun setupCameraParameters()
-        fun showCameraPreview()
+        fun startCameraPreview()
+        fun stopCameraPreview()
         fun setViewSize(adjustedWidth: Int, adjustedHeight: Int)
     }
 

--- a/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRScannerContract.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRScannerContract.kt
@@ -103,7 +103,7 @@ interface OMGQRScannerContract {
         /**
          * Keep failed QR payload that being sent to the server to prevent spamming
          */
-        val qrPayloadCache: MutableList<String>
+        val qrPayloadCache: MutableSet<String>
 
         /**
          * The [Callback] for retrieve the QR validation result

--- a/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRScannerLogic.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRScannerLogic.kt
@@ -60,7 +60,7 @@ internal class OMGQRScannerLogic(
     override var scanCallback: OMGQRScannerContract.Callback? = null
 
     /* Keep the QR payload that being sent to the server to prevent spamming */
-    override val qrPayloadCache: MutableList<String> = mutableListOf()
+    override val qrPayloadCache: MutableSet<String> = mutableSetOf()
 
     /**
      * Rotate the image based on the orientation of the raw image data
@@ -180,7 +180,6 @@ internal class OMGQRScannerLogic(
 
             /* Verify transactionId with the eWallet backend */
             omgQRVerifier.requestTransaction(formattedId, { errorResponse ->
-
                 /* Cache formattedId if error with [ErrorCode.TRANSACTION_REQUEST_NOT_FOUND] code */
                 if (errorResponse.data.code == ErrorCode.TRANSACTION_REQUEST_NOT_FOUND) {
                     qrPayloadCache.add(formattedId)

--- a/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRScannerLogic.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRScannerLogic.kt
@@ -15,10 +15,7 @@ import android.graphics.ImageFormat
 import android.graphics.Rect
 import android.graphics.YuvImage
 import android.hardware.Camera
-import co.omisego.omisego.constant.Versions
 import co.omisego.omisego.constant.enums.ErrorCode
-import co.omisego.omisego.model.APIError
-import co.omisego.omisego.model.OMGResponse
 import co.omisego.omisego.qrcode.scanner.OMGQRScannerContract.Logic.Rotation
 import co.omisego.omisego.qrcode.scanner.utils.QRFrameExtractor
 import co.omisego.omisego.qrcode.scanner.utils.Rotater
@@ -46,16 +43,6 @@ internal class OMGQRScannerLogic(
 ) : OMGQRScannerContract.Logic {
     private var mQRFrameExtractor: QRFrameExtractor? = null
     private var mPreviewSize: Camera.Size? = null
-    private val errorTxNotFound: OMGResponse<APIError> by lazy {
-        OMGResponse(
-            Versions.EWALLET_API,
-            false,
-            APIError(
-                ErrorCode.TRANSACTION_REQUEST_NOT_FOUND,
-                "There is no transaction request corresponding to the provided address"
-            )
-        )
-    }
 
     override var scanCallback: OMGQRScannerContract.Callback? = null
 
@@ -168,12 +155,12 @@ internal class OMGQRScannerLogic(
         )
 
         rawResult?.text?.let { formattedId ->
-
             /* Return immediately if we've already processed this [formattedId] and it failed with [ErrorCode.TRANSACTION_REQUEST_NOT_FOUND] */
             if (hasTransactionAlreadyFailed(formattedId)) {
-                scanCallback?.scannerDidFailToDecode(omgQRScannerView, errorTxNotFound)
                 return@let
             }
+
+            qrPayloadCache.add(formattedId)
 
             /* Show loading */
             omgQRScannerView.isLoading = true
@@ -181,8 +168,8 @@ internal class OMGQRScannerLogic(
             /* Verify transactionId with the eWallet backend */
             omgQRVerifier.requestTransaction(formattedId, { errorResponse ->
                 /* Cache formattedId if error with [ErrorCode.TRANSACTION_REQUEST_NOT_FOUND] code */
-                if (errorResponse.data.code == ErrorCode.TRANSACTION_REQUEST_NOT_FOUND) {
-                    qrPayloadCache.add(formattedId)
+                if (errorResponse.data.code != ErrorCode.TRANSACTION_REQUEST_NOT_FOUND) {
+                    qrPayloadCache.remove(formattedId)
                 }
 
                 /* Delegate a fail callback */
@@ -191,6 +178,7 @@ internal class OMGQRScannerLogic(
                 /* Hide loading */
                 omgQRScannerView.isLoading = false
             }) { successResponse ->
+                qrPayloadCache.remove(formattedId)
 
                 /* Delegate a success callback */
                 scanCallback?.scannerDidDecode(omgQRScannerView, successResponse)

--- a/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRScannerView.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRScannerView.kt
@@ -209,7 +209,7 @@ class OMGQRScannerView : FrameLayout, OMGQRScannerContract.View {
         if (cameraHandlerThread == null)
             cameraHandlerThread = CameraHandlerThread(this)
         cameraHandlerThread?.startCamera()
-        omgScannerLogic = OMGQRScannerLogic(this, OMGQRVerifier(client)).apply {
+        omgScannerLogic = omgScannerLogic ?: OMGQRScannerLogic(this, OMGQRVerifier(client)).apply {
             scanCallback = callback
         }
     }
@@ -222,7 +222,6 @@ class OMGQRScannerView : FrameLayout, OMGQRScannerContract.View {
         cameraWrapper?.camera?.release()
         cameraHandlerThread?.quit()
         cameraHandlerThread = null
-        omgScannerLogic = null
     }
 
     override fun onPreviewFrame(data: ByteArray, camera: Camera) {

--- a/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRVerifier.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRVerifier.kt
@@ -45,7 +45,7 @@ internal class OMGQRVerifier(
         crossinline success: (response: OMGResponse<TransactionRequest>) -> Unit
     ) {
         callable = omgAPIClient.retrieveTransactionRequest(TransactionRequestParams(formattedId))
-        callback = callback ?: object : OMGCallback<TransactionRequest> {
+        callback = object : OMGCallback<TransactionRequest> {
             override fun success(response: OMGResponse<TransactionRequest>) = success(response)
             override fun fail(response: OMGResponse<APIError>) = fail(response)
         }

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/custom/camera/ui/OMGCameraPreviewTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/custom/camera/ui/OMGCameraPreviewTest.kt
@@ -108,7 +108,7 @@ class OMGCameraPreviewTest {
         whenever(spyOMGCameraPreview.mOMGCameraLogic.getDisplayOrientation(true)).thenReturn(0)
         whenever(spyOMGCameraPreview.setupCameraParameters()).thenReturn(null)
 
-        spyOMGCameraPreview.showCameraPreview()
+        spyOMGCameraPreview.startCameraPreview()
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
         verify(camera, times(1)).setPreviewDisplay(any())

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/custom/zxing/ui/core/OMGQRScannerLogicTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/custom/zxing/ui/core/OMGQRScannerLogicTest.kt
@@ -23,6 +23,7 @@ import co.omisego.omisego.qrcode.scanner.OMGQRVerifier
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.Reader
 import com.google.zxing.Result
+import com.nhaarman.mockito_kotlin.spy
 import com.nhaarman.mockito_kotlin.timeout
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
@@ -44,14 +45,16 @@ import java.util.concurrent.Executor
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [23])
 class OMGQRScannerLogicTest {
-    private val retrieveTransactionRequestFile: File by ResourceFile("transaction_request.json")
+    private val transactionRequestSuccessFile: File by ResourceFile("transaction_request.json")
+    private val transactionRequestFailedFile: File by ResourceFile("error-invalid_transaction.json")
     private val omgQRScannerView: OMGQRScannerContract.View = mock()
     private val multiFormatReader: Reader = mock()
     private val sampleByteArray = byteArrayOf(0x00, 0x01, 0x02, 0x03)
-    private lateinit var omgQRScannerPresenter: OMGQRScannerLogic
+    private lateinit var omgQRScannerLogic: OMGQRScannerLogic
     private lateinit var mockWebServer: MockWebServer
     private lateinit var omgAPIClient: OMGAPIClient
     private lateinit var omgQRVerifier: OMGQRVerifier
+    private var mockQRPayloadCache: MutableSet<String> = mock()
     private val mockTransactionRequestCb: OMGCallback<TransactionRequest> = mock()
 
     @Before
@@ -76,21 +79,22 @@ class OMGQRScannerLogicTest {
         omgQRVerifier = OMGQRVerifier(omgAPIClient).apply {
             callback = mockTransactionRequestCb
         }
-        omgQRScannerPresenter = OMGQRScannerLogic(omgQRScannerView, omgQRVerifier, qrReader = multiFormatReader)
+        omgQRScannerLogic = spy(OMGQRScannerLogic(omgQRScannerView, omgQRVerifier, qrReader = multiFormatReader))
+        whenever(omgQRScannerLogic.qrPayloadCache).thenReturn(mockQRPayloadCache)
     }
 
     @Test
     fun `OMGQRScanner should be adjusted the image rotation data correctly`() {
-        val result0 = omgQRScannerPresenter.adjustRotation(sampleByteArray, 2 to 2, 0)
+        val result0 = omgQRScannerLogic.adjustRotation(sampleByteArray, 2 to 2, 0)
         result0 shouldEqual byteArrayOf(0x00, 0x01, 0x02, 0x03)
 
-        val result90 = omgQRScannerPresenter.adjustRotation(sampleByteArray, 2 to 2, 90)
+        val result90 = omgQRScannerLogic.adjustRotation(sampleByteArray, 2 to 2, 90)
         result90 shouldEqual byteArrayOf(0x02, 0x00, 0x03, 0x01)
 
-        val result180 = omgQRScannerPresenter.adjustRotation(sampleByteArray, 2 to 2, 180)
+        val result180 = omgQRScannerLogic.adjustRotation(sampleByteArray, 2 to 2, 180)
         result180 shouldEqual byteArrayOf(0x03, 0x02, 0x01, 0x00)
 
-        val result270 = omgQRScannerPresenter.adjustRotation(sampleByteArray, 2 to 2, 270)
+        val result270 = omgQRScannerLogic.adjustRotation(sampleByteArray, 2 to 2, 270)
         result270 shouldEqual byteArrayOf(0x01, 0x03, 0x00, 0x02)
     }
 
@@ -106,7 +110,7 @@ class OMGQRScannerLogicTest {
         val previewSize = 1920 to 1080
 
         /* Retrieve the adjusted frame */
-        val rect = omgQRScannerPresenter.adjustFrameInPreview(
+        val rect = omgQRScannerLogic.adjustFrameInPreview(
             scannerSize.first to scannerSize.second,
             previewSize.first to previewSize.second,
             qrFrame
@@ -120,12 +124,12 @@ class OMGQRScannerLogicTest {
     }
 
     @Test
-    fun `OMGQRScannerPresenter should not processed the preview frame if the scanner view is still loading`() {
+    fun `OMGQRScannerLogic should not processed the preview frame if the scanner view is still loading`() {
         val scanQRCallback = mock<OMGQRScannerContract.Callback>()
         whenever(omgQRScannerView.isLoading).thenReturn(true)
-        omgQRScannerPresenter.scanCallback = scanQRCallback
+        omgQRScannerLogic.scanCallback = scanQRCallback
 
-        omgQRScannerPresenter.onPreviewFrame(byteArrayOf(),
+        omgQRScannerLogic.onPreviewFrame(byteArrayOf(),
             CameraUtils.cameraInstance!!.apply {
                 parameters.setPreviewSize(480, 720)
             }
@@ -135,9 +139,42 @@ class OMGQRScannerLogicTest {
     }
 
     @Test
-    fun `OMGQRScannerPresenter should be invoked the callback scannerDidDecode when the QR image format is correct`() {
+    fun `OMGQRScannerLogic should be invoked the callback scannerDidDecode when the QR image format is correct`() {
+        transactionRequestSuccessFile.mockEnqueueWithHttpCode(mockWebServer)
+        mockOnPreviewFrameDeps()
+        mockTransactionIdThenPreview("transaction_id_01")
+
+        verify(omgQRScannerView, times(1)).isLoading = true
+        verify(omgQRScannerLogic.scanCallback, timeout(3000).times(1))?.scannerDidDecode(any(), any())
+    }
+
+    @Test
+    fun `OMGQRScannerLogic should be invoked the callback scannerDidFailToDecode when the QR image format is incorrect`() {
+        transactionRequestFailedFile.mockEnqueueWithHttpCode(mockWebServer)
+        mockOnPreviewFrameDeps()
+        mockTransactionIdThenPreview("transaction_id_01")
+
+        verify(omgQRScannerView, times(1)).isLoading = true
+        verify(omgQRScannerLogic.scanCallback, timeout(3000).times(1))?.scannerDidFailToDecode(any(), any())
+    }
+
+    @Test
+    fun `OMGQRScannerLogic should cache the transaction formatted_id properly if it is an invalid transaction`() {
+        for (i in 0..2) {
+            transactionRequestFailedFile.mockEnqueueWithHttpCode(mockWebServer)
+        }
+        mockOnPreviewFrameDeps()
+
+        mockTransactionIdThenPreview("transaction_id_01")
+        mockTransactionIdThenPreview("transaction_id_02")
+        verify(mockQRPayloadCache, timeout(3000).times(1)).add("transaction_id_02")
+
+        mockTransactionIdThenPreview("transaction_id_01")
+        verify(mockQRPayloadCache, timeout(3000).times(1)).add("transaction_id_01")
+    }
+
+    private fun mockOnPreviewFrameDeps() {
         val mockScanQRCallback = mock<OMGQRScannerContract.Callback>()
-        retrieveTransactionRequestFile.mockEnqueueWithHttpCode(mockWebServer)
         whenever(omgQRScannerView.isLoading).thenReturn(false)
         whenever(omgQRScannerView.debugging).thenReturn(false)
         whenever(omgQRScannerView.orientation).thenReturn(Configuration.ORIENTATION_PORTRAIT)
@@ -149,28 +186,29 @@ class OMGQRScannerLogicTest {
         whenever(omgQRScannerView.omgScannerUI.mFramingRect).thenReturn(
             Rect(100, 100, 356, 356)
         )
+
+        omgQRScannerLogic.scanCallback = mockScanQRCallback
+    }
+
+    private fun mockTransactionIdThenPreview(transactionId: String) {
         whenever(multiFormatReader.decode(any())).thenReturn(
-            Result("OMG", ByteArray(518400), arrayOf(), BarcodeFormat.QR_CODE)
+            Result(transactionId, ByteArray(518400), arrayOf(), BarcodeFormat.QR_CODE)
         )
 
-        omgQRScannerPresenter.scanCallback = mockScanQRCallback
-        omgQRScannerPresenter.onPreviewFrame(
+        omgQRScannerLogic.onPreviewFrame(
             ByteArray(518400),
             CameraUtils.cameraInstance!!.apply {
                 parameters.setPreviewSize(720, 480)
             }
         )
-
-        verify(omgQRScannerView, times(1)).isLoading = true
-        verify(mockTransactionRequestCb, timeout(3000).times(1)).success(any())
     }
 
     @Test
-    fun `OMGQRScannerPresenter should delegate callback correctly when the user tap to cancel loading`() {
+    fun `OMGQRScannerLogic should delegate callback correctly when the user tap to cancel loading`() {
         val mockScanQRCallback = mock<OMGQRScannerContract.Callback>()
 
-        omgQRScannerPresenter.scanCallback = mockScanQRCallback
-        omgQRScannerPresenter.cancelLoading()
+        omgQRScannerLogic.scanCallback = mockScanQRCallback
+        omgQRScannerLogic.cancelLoading()
 
         verify(mockScanQRCallback, times(1)).scannerDidCancel(omgQRScannerView)
         verifyNoMoreInteractions(mockScanQRCallback)

--- a/omisego-sdk/src/test/resources/error-invalid_transaction.json
+++ b/omisego-sdk/src/test/resources/error-invalid_transaction.json
@@ -1,0 +1,8 @@
+{
+  "version": "1",
+  "success": false,
+  "data": {
+    "description": "There is no transaction request corresponding to the provided ID.",
+    "code": "transaction_request:transaction_request_not_found"
+  }
+}


### PR DESCRIPTION
Issue/Task Number: `462-fix-bug-qr-scanner-doesnt-cache-invalid-transaction-id-properly`

# Overview

From the issue #51 

Currently, the SDK doesn't cache the invalid transaction id properly because of we **cache** the 
inlined callback (`success` and `fail`) of API `getTransaction` so the `formattedId` inside the callback is always the same.

**Bug**
```kotlin
callback = callback ?: object : OMGCallback<TransactionRequest> {
  override fun success(response: OMGResponse<TransactionRequest>) = success(response)
  override fun fail(response: OMGResponse<APIError>) = fail(response)
}
```

**Bug-free**
```kotlin
callback = object : OMGCallback<TransactionRequest> {
  override fun success(response: OMGResponse<TransactionRequest>) = success(response)
  override fun fail(response: OMGResponse<APIError>) = fail(response)
}
```

![test_scanner](https://user-images.githubusercontent.com/4509570/42046852-fc179adc-7b28-11e8-9706-07add05050c8.gif)


# Changes

1. Solved the bug
2. Improved consistency of the method name
3. Added more test

# Usage

Same

# Impact

`N/A`