### PR TITLE
Support `TransactionExchange` rate to be nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and `OmiseGO` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.0.1] - 2018-06-12
+### Changed
+- Change `TransactionExchange` rate to nullable type
+
 ## [1.0.0] - 2018-07-6
 ### Added
 - Added documentation for missing fields in `TransactionRequest`
@@ -90,7 +94,8 @@ and `OmiseGO` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Logout the current user
 - [OMGKeyManager - encryption and decryption helpers](https://github.com/omisego/android-sdk/pull/11)
 
-[Unreleased]: https://github.com/omisego/android-sdk/compare/v0.9.6...HEAD
+[Unreleased]: https://github.com/omisego/android-sdk/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/omisego/android-sdk/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/omisego/android-sdk/compare/v0.9.6...v1.0.0
 [0.9.6]: https://github.com/omisego/android-sdk/compare/v0.9.52...v0.9.6
 [0.9.52]: https://github.com/omisego/android-sdk/compare/v0.9.51...v0.9.52

--- a/build.gradle
+++ b/build.gradle
@@ -31,5 +31,5 @@ task clean(type: Delete) {
 }
 
 ext {
-    versionName = "1.0.0"
+    versionName = "1.0.1"
 }

--- a/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/Transaction.kt
+++ b/omisego-sdk/src/main/java/co/omisego/omisego/model/transaction/Transaction.kt
@@ -20,7 +20,7 @@ import java.util.Date
 
 @Parcelize
 data class TransactionExchange(
-    val rate: BigDecimal,
+    val rate: BigDecimal?,
     val calculatedAt: Date?,
     val exchangePairId: String?,
     val exchangePair: ExchangePair?,

--- a/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/TransactionExchangeTest.kt
+++ b/omisego-sdk/src/test/kotlin/co/omisego/omisego/model/transaction/TransactionExchangeTest.kt
@@ -7,7 +7,6 @@ package co.omisego.omisego.model.transaction
  * Copyright © 2017-2018 OmiseGO. All rights reserved.
  */
 
-import co.omisego.omisego.extension.bd
 import co.omisego.omisego.helpers.delegation.GsonDelegator
 import co.omisego.omisego.helpers.delegation.ResourceFile
 import co.omisego.omisego.model.Account
@@ -25,7 +24,7 @@ class TransactionExchangeTest : GsonDelegator() {
     fun `test transaction_exchange parsing`() {
         val exchange = gson.fromJson(transactionExchangeFile.readText(), TransactionExchange::class.java)
         with(exchange) {
-            rate shouldEqual 0.017.bd
+            rate shouldEqual null
             calculatedAt shouldEqual dateConverter.fromString("2018-01-01T00:00:00Z")
             exchangePairId shouldEqual "exg_01cgvppyrz2pprj6s0zmc26p2p"
             exchangePair shouldBeInstanceOf ExchangePair::class.java

--- a/omisego-sdk/src/test/resources/object/transaction_exchange.json
+++ b/omisego-sdk/src/test/resources/object/transaction_exchange.json
@@ -1,6 +1,6 @@
 {
   "object": "exchange",
-  "rate": 0.017,
+  "rate": null,
   "calculated_at": "2018-01-01T00:00:00Z",
   "exchange_pair_id": "exg_01cgvppyrz2pprj6s0zmc26p2p",
   "exchange_pair": {


### PR DESCRIPTION
Issue/Task Number: `513-support-transaction-exchange-rate-null`

# Overview

This PR adds support `TransactionExchange` rate to be nullable