### PR TITLE
Prepare submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Local configuration file (sdk path, etc)
 local.properties
 secret.json
+settings.gradle
 
 # Android Studio
 .externalNativeBuild
@@ -25,3 +26,6 @@ myapplication
 /.idea/misc.xml
 /.idea/libraries
 /.idea/dictionaries
+/.idea/vcs.xml
+
+# sample-android

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sample-android"]
+	path = sample-android
+	url = https://github.com/omisego/sample-android.git

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
-include ':omisego-sdk'
+include ':omisego-sdk', ':app'
+project(':app').projectDir = new File('sample-android/app')


### PR DESCRIPTION
Issue/Task Number: `524-add-sample-app-as-a-submodule-to-android-sdk`

# Overview

This PR will add the `sample-android` project to be a submodule of `android-sdk`.

**Why?**
1. The strongest reason for me is to make a sample app be able to use the local SDK directly as a dependency without exporting `.aar` file (the library format for android) because they're live in the same project. This will make the SDK development process become much easier for me because we can test the feature with the sample app immediately.

2. No need to open 2 projects anymore (the SDK and the sample app).

3. We can still completely separate the sample app repo from the android-sdk repo.

![screenshot 2561-07-16 at 14 00 13](https://user-images.githubusercontent.com/4509570/42746232-0783fd58-8901-11e8-9526-f542363b74c4.png)

(When clicking at the `gitlink`, the browser will be redirected to the sample-android repo)