### PR TITLE
Fix camera out of memory issue

### DIFF
--- a/omisego-core/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRScannerPreview.kt
+++ b/omisego-core/src/main/java/co/omisego/omisego/qrcode/scanner/OMGQRScannerPreview.kt
@@ -63,9 +63,7 @@ internal class OMGQRScannerPreview(
 
             val previewOrientation = GlobalScope.async(Dispatchers.IO) { getPreviewOrientation() }
             val previewSize = nullablePreviewSize?.await() ?: return@launch
-            val rawResult = GlobalScope.async(Dispatchers.IO) {
-                decoder.decode(data, previewOrientation.await(), previewSize)
-            }.await()
+            val rawResult = decoder.decode(data, previewOrientation.await(), previewSize)
 
             /* Wait result in the UI thread */
             rawResult?.text?.let { text ->


### PR DESCRIPTION
Issue/Task Number: #80 

Closes #80

# Overview

This PR fixes issue about the QR scanner camera that randomly crashes due to out of memory issue.

The cause is that the coroutine decodes multiple camera preview frames simultaneously and it keeps stacking the byte array in the decode method.

The solution basically processes the frames one by one (stop decoding the frame in parallel).

> Note: This issue happens after migrate the coroutine version to 1.0
